### PR TITLE
Fix false "not a git repo" warnings in gws ls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ profile.cov
 go.work
 go.work.sum
 
+# Go build cache (set via GOCACHE for sandboxed runs)
+.gocache/
+
 # env file
 .env
 

--- a/internal/core/gitcmd/runner.go
+++ b/internal/core/gitcmd/runner.go
@@ -125,6 +125,7 @@ var allowedSubcommands = map[string]struct{}{
 	"fetch":            {},
 	"init":             {},
 	"ls-remote":        {},
+	"rev-parse":        {},
 	"remote":           {},
 	"show-ref":         {},
 	"symbolic-ref":     {},


### PR DESCRIPTION
Summary
- allow the git subcommand rev-parse so workspace scanning can detect git repos correctly
- ignore the sandboxed local Go build cache (.gocache) to avoid stray untracked files

Testing
- GOCACHE=/Users/tasuku43/gws/workspaces/fix-warnings/gws/.gocache gofmt -w .
- GOCACHE=/Users/tasuku43/gws/workspaces/fix-warnings/gws/.gocache go test ./...
- GOCACHE=/Users/tasuku43/gws/workspaces/fix-warnings/gws/.gocache go run ./cmd/gws ls