### PR TITLE
Add interactive issue picker for gws issue

### DIFF
--- a/docs/specs/issue.md
+++ b/docs/specs/issue.md
@@ -1,8 +1,6 @@
 title: "gws issue"
 status: implemented
-pending:
-  - interactive-issue-picker
-  - multi-issue-workspaces
+pending: []
 ---
 
 ## Synopsis

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -26,7 +26,7 @@ func printGlobalHelp(w io.Writer) {
 	fmt.Fprintln(w, "  rm [<ID>]                          remove workspace (clean only)")
 	fmt.Fprintln(w, "  open [<ID>]                        open workspace in subshell")
 	fmt.Fprintln(w, "  review <PR URL>                    create review workspace from PR")
-	fmt.Fprintln(w, "  issue <ISSUE URL>                  create issue workspace from issue")
+	fmt.Fprintln(w, "  issue [<ISSUE URL>]                create issue workspace from issue")
 	fmt.Fprintln(w, "  repo <subcommand>                  repo commands (get/ls)")
 	fmt.Fprintln(w, "  template <subcommand>              template commands (ls)")
 	fmt.Fprintln(w, "  doctor [--fix]                     check workspace/repo health")
@@ -107,9 +107,10 @@ func printReviewHelp(w io.Writer) {
 }
 
 func printIssueHelp(w io.Writer) {
-	fmt.Fprintln(w, "Usage: gws issue <ISSUE_URL> [--workspace-id <id>] [--branch <name>] [--base <ref>]")
-	fmt.Fprintln(w, "  Create a workspace for a single issue (GitHub, GitLab, Bitbucket)")
+	fmt.Fprintln(w, "Usage: gws issue [<ISSUE_URL>] [--workspace-id <id>] [--branch <name>] [--base <ref>]")
+	fmt.Fprintln(w, "  Create workspace(s) for issue(s) (GitHub, GitLab, Bitbucket)")
 	fmt.Fprintln(w, "  default workspace id: ISSUE-<number>, branch: issue/<number>")
+	fmt.Fprintln(w, "  without ISSUE_URL: pick repo + issues interactively")
 }
 
 func printRepoHelp(w io.Writer) {

--- a/internal/cli/issue_picker_test.go
+++ b/internal/cli/issue_picker_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import "testing"
+
+func TestParseGitHubIssues(t *testing.T) {
+	data := []byte(`[
+  {"number": 1, "title": "Fix bug"},
+  {"number": 2, "title": "PR", "pull_request": {}},
+  {"number": 3, "title": "  Add feature  "}
+]`)
+	issues, err := parseGitHubIssues(data)
+	if err != nil {
+		t.Fatalf("parseGitHubIssues error: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+	if issues[0].Number != 1 || issues[0].Title != "Fix bug" {
+		t.Fatalf("unexpected first issue: %+v", issues[0])
+	}
+	if issues[1].Number != 3 || issues[1].Title != "Add feature" {
+		t.Fatalf("unexpected second issue: %+v", issues[1])
+	}
+}
+
+func TestParseGitHubIssuesInvalidJSON(t *testing.T) {
+	if _, err := parseGitHubIssues([]byte(`{`)); err == nil {
+		t.Fatalf("expected error for invalid JSON")
+	}
+}


### PR DESCRIPTION
## Summary

* Add an interactive issue picker with repository selection and multi-issue selection.
* Fetch GitHub issues and create workspaces sequentially.
* Add generic UI selection helpers and tests for GitHub issue parsing.
* Update help text and mark issue spec pending items as done.

## Notes

* GitHub-only in picker mode for now. Follow-up: [https://github.com/tasuku43/gws/issues/27](https://github.com/tasuku43/gws/issues/27)
