### PR TITLE
docs: rm multi-select spec

### DIFF
--- a/docs/specs/rm.md
+++ b/docs/specs/rm.md
@@ -11,8 +11,18 @@ Safely remove a workspace and all of its worktrees, refusing when repositories a
 
 ## Behavior
 - With `WORKSPACE_ID` provided: targets that workspace.
-- Without it: scans workspaces, classifies each as removable or blocked (dirty or status errors), and prompts the user to choose one of the removable entries. Fails if none are removable.
+- Without it: scans workspaces, classifies each as removable or blocked (dirty or status errors), and prompts the user to choose removable entries using the same add/remove loop as `gws create` issue Step 3. Fails if none are removable.
+- Multi-select UX:
+  - Shows only removable entries for selection.
+  - Blocked entries are listed in an Info section (same as current behavior) but are not selectable.
+  - `<Enter>` adds the highlighted workspace to the selection list and removes it from candidates.
+  - Finish keys: `<Ctrl+D>` or typing `done` then `<Enter>`; minimum 1 selection required.
+  - Empty input + `<Enter>` does nothing (stays in loop).
+  - Filterable list by substring (case-insensitive); lightweight fuzzy match is acceptable.
 - Before removal, gathers warnings (e.g., ahead-of-upstream, missing upstream, status errors) and displays them.
+- Before removal, if multiple workspaces are selected, ask for confirmation:
+  - Prompt: `Remove N workspaces? (y/N)`
+  - Default is No.
 - Calls `workspace.Remove`, which:
   - Validates the workspace exists.
   - Fails if any repo has uncommitted/untracked/unstaged/unmerged changes.


### PR DESCRIPTION
## Summary
- add multi-select loop details to `gws rm` spec
- keep blocked entries as Info-only, add confirmation prompt for multi-removal

## Testing
- not run (docs only)