### PR TITLE
Prefix workspace in gws open prompt

### DIFF
--- a/docs/specs/open.md
+++ b/docs/specs/open.md
@@ -19,7 +19,7 @@ Open a workspace by launching an interactive subshell at the workspace root, mak
 - Wires STDIN/STDOUT/STDERR for direct interaction.
 - Optionally sets `GWS_WORKSPACE=<WORKSPACE_ID>` for the child process.
 - For shells `bash`, `zsh`, `sh`, prepends a prompt prefix to the child process `PS1`:
-  - Prefix format: `[gws:<WORKSPACE_ID>] `
+  - Prefix format: `[gws:<WORKSPACE_ID>] ` (blue)
   - If `PS1` is empty or unset, the prefix alone becomes `PS1`.
   - Only the child process receives the modified `PS1`; the parent shell is not changed.
 - When the subshell exits, `gws open` exits and the parent shell cwd remains unchanged.

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -184,7 +184,7 @@ func prepareBashPromptOverride(workspaceID string) (*promptOverride, error) {
 	}
 	rcfile := filepath.Join(dir, "bashrc")
 	home := os.Getenv("HOME")
-	prefix := fmt.Sprintf("[gws:%s] ", workspaceID)
+	prefix := fmt.Sprintf("\\[\\033[34m\\][gws:%s]\\[\\033[0m\\] ", workspaceID)
 	content := strings.Join([]string{
 		"# gws open prompt wrapper",
 		fmt.Sprintf("if [ -r %s ]; then . %s; fi", strconv.Quote(filepath.Join(home, ".bashrc")), strconv.Quote(filepath.Join(home, ".bashrc"))),
@@ -224,7 +224,7 @@ func prepareZshPromptOverride(workspaceID string) (*promptOverride, error) {
 	if origZdot == "" {
 		origZdot = home
 	}
-	prefix := fmt.Sprintf("[gws:%s] ", workspaceID)
+	prefix := fmt.Sprintf("%%F{blue}[gws:%s]%%f ", workspaceID)
 	content := strings.Join([]string{
 		"# gws open prompt wrapper",
 		fmt.Sprintf("orig=${GWS_ZDOTDIR_ORIG:-%s}", strconv.Quote(origZdot)),
@@ -271,7 +271,7 @@ func prepareShPromptOverride(workspaceID string) (*promptOverride, error) {
 	}
 	rcfile := filepath.Join(dir, "shrc")
 	origEnv := os.Getenv("ENV")
-	prefix := fmt.Sprintf("[gws:%s] ", workspaceID)
+	prefix := fmt.Sprintf("\\033[34m[gws:%s]\\033[0m ", workspaceID)
 	content := strings.Join([]string{
 		"# gws open prompt wrapper",
 		fmt.Sprintf("orig=${GWS_ENV_ORIG:-%s}", strconv.Quote(origEnv)),


### PR DESCRIPTION
## Summary
- prefix the subshell prompt with `[gws:<ID>]` in blue for bash/zsh/sh
- keep parent shell unchanged; handle zsh history/temp setup
- update spec for prompt behavior

## Testing
- go test ./...