### PR TITLE
Add workspace descriptions to metadata and lists

### DIFF
--- a/docs/DIRECTORY_LAYOUT.md
+++ b/docs/DIRECTORY_LAYOUT.md
@@ -11,6 +11,7 @@
 - `$GWS_ROOT/workspaces/`     : workspace (AI)
 - `$GWS_ROOT/workspaces/<ID>/`:
     - `<alias>/`        : worktree 作業ディレクトリ
+    - `.gws/metadata.json` : workspace のメタデータ（description など）
 
 ## repo store のパス
 - `$GWS_ROOT/bare/<host>/<owner>/<repo>.git`

--- a/docs/specs/create.md
+++ b/docs/specs/create.md
@@ -22,6 +22,7 @@ Same behavior as the former `gws new`.
 - Resolves `--template` and `WORKSPACE_ID`; if either is missing and `--no-prompt` is not set, interactively prompts for both. With `--no-prompt`, missing values cause an error.
 - Validates `WORKSPACE_ID` using `git check-ref-format --branch` and fails on invalid IDs.
 - Loads the specified template from `templates.yaml`; errors if the template is missing.
+- When prompting is allowed, asks for an optional description (`description`). Empty input is allowed; non-empty values are saved as workspace metadata.
 - Preflights template repositories to see which stores are absent.
   - If repos are missing and prompting is allowed, offers to run `gws repo get` for them before proceeding.
   - With `--no-prompt`, missing repos cause an error.
@@ -55,6 +56,7 @@ Same behavior as the former `gws review`.
 - If `PR URL` is provided:
   - Accepts GitHub PR URLs only (e.g., `https://github.com/owner/repo/pull/123`); rejects other hosts or malformed paths.
   - Uses `gh api` to fetch PR metadata (requires authenticated GitHub CLI): PR number, head ref, and repositories.
+  - Saves the PR title as the workspace description.
   - Rejects forked PRs (head repo must match base repo).
   - Selects the repo URL based on `defaultRepoProtocol` (SSH preferred, HTTPS fallback).
   - Workspace ID is `REVIEW-PR-<number>`; errors if it already exists.
@@ -71,6 +73,7 @@ Same behavior as the former `gws review`.
   - For each selected PR:
     - Workspace ID = `REVIEW-PR-<number>`.
     - Branch = PR head ref; base ref = `refs/remotes/origin/<head_ref>`.
+    - Workspace description = PR title.
     - Fork PRs remain rejected.
   - Flags other than `--no-prompt` are not allowed in picker mode (error if provided).
   - Creation is sequential; an error on one PR stops further creation and reports successes/failures so far.
@@ -96,6 +99,7 @@ Same behavior as the former `gws issue`.
   - Parse the URL to obtain `owner`, `repo`, and `issue number`.
   - Workspace ID: defaults to `ISSUE-<number>`; can be overridden with `--workspace-id`. Must pass `git check-ref-format --branch`. If the workspace already exists, error.
   - Branch: defaults to `issue/<number>`. Before proceeding, prompt the user with the default and allow editing unless `--no-prompt` or `--branch` is supplied.
+  - For GitHub issues, uses `gh api` to fetch the issue title and saves it as the workspace description.
     - If the branch exists in the bare store, use it.
     - If not, create it from a base ref.
   - Base ref: defaults to the standard detection used by `gws add` (prefer `HEAD`, then `origin/HEAD`, then `main`/`master`/`develop` locally or on origin). `--base` overrides detection; must resolve in the bare store or as `origin/<ref>`.
@@ -112,6 +116,7 @@ Same behavior as the former `gws issue`.
   - For each selected issue:
     - Workspace ID = `ISSUE-<number>` (no per-item override in this flow).
     - Branch = `issue/<number>`.
+    - Workspace description = issue title.
     - Base ref detection and repo missing handling are the same as the URL path.
   - Flags `--workspace-id`, `--branch`, and `--base` are only valid when a single issue is targeted (URL path). In picker mode with multiple selections, using these flags is an error.
   - Creation is sequential; an error on one issue stops further creation and reports successes/failures so far.

--- a/docs/specs/ls.md
+++ b/docs/specs/ls.md
@@ -14,6 +14,7 @@ List workspaces under `<root>/workspaces` and show a quick view of the repos att
 ## Behavior
 - Scans `<root>/workspaces` for directories; ignores non-directories.
 - For each workspace, scans its contents to discover repo worktrees (alias, repo key, branch, path) and renders them in a tree view.
+- If a workspace description is available, show it alongside the workspace ID.
 - Collects and reports non-fatal warnings from scanning workspaces or repos.
 - `--search <query>`: prefilters the list using case-insensitive substring match against workspace ID and repo aliases/paths. Applies to both normal and selection mode.
 - `--select`: launches an interactive TUI picker (requires TTY; errors under `--no-prompt`) that lists the filtered workspaces with live search. On `<Enter>`, returns the selected workspace ID to stdout (single line, no sections) and exits 0. If nothing to select, returns an error.

--- a/docs/specs/rm.md
+++ b/docs/specs/rm.md
@@ -13,7 +13,7 @@ Safely remove a workspace and all of its worktrees, refusing when repositories a
 - With `WORKSPACE_ID` provided: targets that workspace.
 - Without it: scans workspaces, classifies each as removable or blocked (dirty or status errors), and prompts the user to choose removable entries using the same add/remove loop as `gws create` issue Step 3. Fails if none are removable.
 - Multi-select UX:
-  - Shows only removable entries for selection.
+  - Shows only removable entries for selection (including any saved workspace descriptions).
   - Blocked entries are listed in an Info section (same as current behavior) but are not selectable.
   - `<Enter>` adds the highlighted workspace to the selection list and removes it from candidates.
   - Finish keys: `<Ctrl+D>` or typing `done` then `<Enter>`; minimum 1 selection required.

--- a/internal/domain/workspace/metadata.go
+++ b/internal/domain/workspace/metadata.go
@@ -1,0 +1,71 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	metadataDirName  = ".gws"
+	metadataFileName = "metadata.json"
+)
+
+type Metadata struct {
+	Description string `json:"description,omitempty"`
+}
+
+func LoadMetadata(wsDir string) (Metadata, error) {
+	if strings.TrimSpace(wsDir) == "" {
+		return Metadata{}, fmt.Errorf("workspace dir is required")
+	}
+	path := metadataPath(wsDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Metadata{}, nil
+		}
+		return Metadata{}, fmt.Errorf("read metadata: %w", err)
+	}
+	var meta Metadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return Metadata{}, fmt.Errorf("parse metadata: %w", err)
+	}
+	return meta, nil
+}
+
+func SaveMetadata(wsDir string, meta Metadata) error {
+	if strings.TrimSpace(wsDir) == "" {
+		return fmt.Errorf("workspace dir is required")
+	}
+	meta.Description = strings.TrimSpace(meta.Description)
+	if meta.Description == "" {
+		return nil
+	}
+	dir := filepath.Join(wsDir, metadataDirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create metadata dir: %w", err)
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+	if err := os.WriteFile(metadataPath(wsDir), data, 0o644); err != nil {
+		return fmt.Errorf("write metadata: %w", err)
+	}
+	return nil
+}
+
+func ReadDescription(wsDir string) (string, error) {
+	meta, err := LoadMetadata(wsDir)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(meta.Description), nil
+}
+
+func metadataPath(wsDir string) string {
+	return filepath.Join(wsDir, metadataDirName, metadataFileName)
+}

--- a/internal/domain/workspace/metadata_test.go
+++ b/internal/domain/workspace/metadata_test.go
@@ -1,0 +1,65 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListIncludesDescription(t *testing.T) {
+	rootDir := t.TempDir()
+	wsRoot := filepath.Join(rootDir, "workspaces")
+	if err := os.MkdirAll(wsRoot, 0o755); err != nil {
+		t.Fatalf("create workspaces dir: %v", err)
+	}
+
+	ws1 := filepath.Join(wsRoot, "WS-1")
+	if err := os.MkdirAll(ws1, 0o755); err != nil {
+		t.Fatalf("create WS-1 dir: %v", err)
+	}
+	if err := SaveMetadata(ws1, Metadata{Description: "test description"}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	ws2 := filepath.Join(wsRoot, "WS-2")
+	if err := os.MkdirAll(ws2, 0o755); err != nil {
+		t.Fatalf("create WS-2 dir: %v", err)
+	}
+
+	ws3 := filepath.Join(wsRoot, "WS-3")
+	if err := os.MkdirAll(ws3, 0o755); err != nil {
+		t.Fatalf("create WS-3 dir: %v", err)
+	}
+	badDir := filepath.Join(ws3, metadataDirName)
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatalf("create metadata dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, metadataFileName), []byte("{"), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	entries, warnings, err := List(rootDir)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected warnings for invalid metadata")
+	}
+
+	var ws1Desc string
+	var ws2Desc string
+	for _, entry := range entries {
+		if entry.WorkspaceID == "WS-1" {
+			ws1Desc = entry.Description
+		}
+		if entry.WorkspaceID == "WS-2" {
+			ws2Desc = entry.Description
+		}
+	}
+	if ws1Desc != "test description" {
+		t.Fatalf("WS-1 description = %q, want %q", ws1Desc, "test description")
+	}
+	if ws2Desc != "" {
+		t.Fatalf("WS-2 description = %q, want empty", ws2Desc)
+	}
+}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -19,8 +19,9 @@ type PromptChoice struct {
 }
 
 type WorkspaceChoice struct {
-	ID    string
-	Repos []PromptChoice
+	ID          string
+	Description string
+	Repos       []PromptChoice
 }
 
 type BlockedChoice struct {
@@ -1659,9 +1660,18 @@ func renderWorkspaceChoiceList(b *strings.Builder, items []WorkspaceChoice, curs
 		return
 	}
 	for i, item := range items {
-		display := item.ID
+		displayID := item.ID
 		if i == cursor && useColor {
-			display = lipgloss.NewStyle().Bold(true).Render(display)
+			displayID = lipgloss.NewStyle().Bold(true).Render(displayID)
+		}
+		display := displayID
+		desc := strings.TrimSpace(item.Description)
+		if desc != "" {
+			if useColor {
+				display += theme.Muted.Render(" - " + desc)
+			} else {
+				display += " - " + desc
+			}
 		}
 		b.WriteString(fmt.Sprintf("%s%s %s\n", output.Indent+output.Indent, mutedToken(theme, useColor, output.LogConnector), display))
 		if len(item.Repos) == 0 {

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -55,6 +55,30 @@ func (r *Renderer) Bullet(text string) {
 	r.bullet(text)
 }
 
+func (r *Renderer) BulletWithDescription(id, description, suffix string) {
+	prefix := output.StepPrefix + " "
+	if r.useColor {
+		prefix = r.theme.Muted.Render(prefix)
+	}
+	line := id
+	desc := strings.TrimSpace(description)
+	if desc != "" {
+		if r.useColor {
+			line += r.theme.Muted.Render(" - " + desc)
+		} else {
+			line += " - " + desc
+		}
+	}
+	if strings.TrimSpace(suffix) != "" {
+		value := " " + strings.TrimSpace(suffix)
+		if r.useColor {
+			value = r.theme.Muted.Render(value)
+		}
+		line += value
+	}
+	r.writeLine(output.Indent + prefix + line)
+}
+
 func (r *Renderer) BulletError(text string) {
 	prefix := output.StepPrefix + " "
 	if r.useColor {


### PR DESCRIPTION
## Summary
- store optional workspace descriptions in .gws/metadata.json
- show descriptions in lists and selection UIs with muted styling
- populate descriptions from template prompt and PR/issue titles

## Testing
- go test ./...