### PR TITLE
Fix review/issue workspace IDs and tracking

### DIFF
--- a/docs/specs/create.md
+++ b/docs/specs/create.md
@@ -59,20 +59,21 @@ Same behavior as the former `gws review`.
   - Saves the PR title as the workspace description.
   - Rejects forked PRs (head repo must match base repo).
   - Selects the repo URL based on `defaultRepoProtocol` (SSH preferred, HTTPS fallback).
-  - Workspace ID is `REVIEW-PR-<number>`; errors if it already exists.
+  - Workspace ID is `REVIEW-PR-<number>-<owner>-<repo>`; errors if it already exists.
   - Ensures the repo store exists, prompting to run `gws repo get` if missing (unless `--no-prompt`, which fails instead).
   - Fetches the PR head ref into the bare store: `git fetch origin <head_ref>`.
   - Adds a worktree under `<root>/workspaces/REVIEW-PR-<number>/<alias>` where:
-    - Branch is `<head_ref>`.
-    - Base ref is `refs/remotes/origin/<head_ref>`.
+    - Creates a local branch `<head_ref>` tracking `origin/<head_ref>`.
+    - Workspace metadata stores branch name as `<head_ref>`.
 - If `PR URL` is omitted and prompts are allowed (interactive picker):
   - `--no-prompt` with no URL => error.
   - Step 1: pick a repo from fetched bare stores whose origin remote is GitHub. Display `alias (owner/repo)`; filterable by substring.
   - Step 2: fetch open PRs for the repo via `gh api` (latest 50 open, sorted by updated desc).
   - Step 3: multi-select PRs using the same add/remove loop as `gws template new` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
   - For each selected PR:
-    - Workspace ID = `REVIEW-PR-<number>`.
-    - Branch = PR head ref; base ref = `refs/remotes/origin/<head_ref>`.
+    - Workspace ID = `REVIEW-PR-<number>-<owner>-<repo>`.
+    - Creates a local branch matching the PR head ref, tracking `origin/<head_ref>`.
+    - Workspace metadata stores branch name as the PR head ref.
     - Workspace description = PR title.
     - Fork PRs remain rejected.
   - Flags other than `--no-prompt` are not allowed in picker mode (error if provided).
@@ -97,7 +98,7 @@ Same behavior as the former `gws issue`.
 ### Behavior
 - If `ISSUE_URL` is provided:
   - Parse the URL to obtain `owner`, `repo`, and `issue number`.
-  - Workspace ID: defaults to `ISSUE-<number>`; can be overridden with `--workspace-id`. Must pass `git check-ref-format --branch`. If the workspace already exists, error.
+  - Workspace ID: defaults to `ISSUE-<number>-<owner>-<repo>`; can be overridden with `--workspace-id`. Must pass `git check-ref-format --branch`. If the workspace already exists, error.
   - Branch: defaults to `issue/<number>`. Before proceeding, prompt the user with the default and allow editing unless `--no-prompt` or `--branch` is supplied.
   - For GitHub issues, uses `gh api` to fetch the issue title and saves it as the workspace description.
     - If the branch exists in the bare store, use it.
@@ -114,7 +115,7 @@ Same behavior as the former `gws issue`.
   - Step 2: fetch open issues for the chosen repo from the host API (GitHub via `gh api`; other hosts may be added later). Default fetch: latest 50 open issues sorted by updated desc.
   - Step 3: multi-select issues using the same add/remove loop as `gws template new` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
   - For each selected issue:
-    - Workspace ID = `ISSUE-<number>` (no per-item override in this flow).
+    - Workspace ID = `ISSUE-<number>-<owner>-<repo>` (no per-item override in this flow).
     - Branch = `issue/<number>`.
     - Workspace description = issue title.
     - Base ref detection and repo missing handling are the same as the URL path.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -829,7 +829,7 @@ func runCreateIssue(ctx context.Context, rootDir, issueURL, workspaceID, branch,
 
 	branchProvided := branch != ""
 	if workspaceID == "" {
-		workspaceID = fmt.Sprintf("ISSUE-%d", req.Number)
+		workspaceID = fmt.Sprintf("ISSUE-%d-%s-%s", req.Number, req.Owner, req.Repo)
 	}
 	if branch == "" {
 		branch = fmt.Sprintf("issue/%d", req.Number)
@@ -970,7 +970,7 @@ func runIssue(ctx context.Context, rootDir string, args []string, noPrompt bool)
 
 	branchProvided := branch != ""
 	if workspaceID == "" {
-		workspaceID = fmt.Sprintf("ISSUE-%d", req.Number)
+		workspaceID = fmt.Sprintf("ISSUE-%d-%s-%s", req.Number, req.Owner, req.Repo)
 	}
 	if branch == "" {
 		branch = fmt.Sprintf("issue/%d", req.Number)
@@ -1157,7 +1157,7 @@ func runIssuePicker(ctx context.Context, rootDir string, noPrompt bool, title st
 		if issue, ok := issueByNumber[num]; ok {
 			description = issue.Title
 		}
-		workspaceID := fmt.Sprintf("ISSUE-%d", num)
+		workspaceID := fmt.Sprintf("ISSUE-%d-%s-%s", num, selectedRepo.Owner, selectedRepo.Repo)
 		branch := fmt.Sprintf("issue/%d", num)
 		output.Step(formatStep("create workspace", workspaceID, relPath(rootDir, filepath.Join(rootDir, "workspaces", workspaceID))))
 		wsDir, err := workspace.New(ctx, rootDir, workspaceID)
@@ -1422,7 +1422,7 @@ func runCreateReview(ctx context.Context, rootDir, prURL string, noPrompt bool) 
 		}
 	}
 
-	workspaceID := fmt.Sprintf("REVIEW-PR-%d", pr.Number)
+	workspaceID := fmt.Sprintf("REVIEW-PR-%d-%s-%s", pr.Number, baseOwner, baseRepo)
 	output.Step(formatStep("create workspace", workspaceID, relPath(rootDir, filepath.Join(rootDir, "workspaces", workspaceID))))
 	wsDir, err := workspace.New(ctx, rootDir, workspaceID)
 	if err != nil {
@@ -1443,9 +1443,9 @@ func runCreateReview(ctx context.Context, rootDir, prURL string, noPrompt bool) 
 		return err
 	}
 
-	baseRef := fmt.Sprintf("refs/remotes/origin/%s", pr.HeadRef)
+	headRef := fmt.Sprintf("refs/remotes/origin/%s", pr.HeadRef)
 	output.Step(formatStep("worktree add", displayRepoName(repoURL), worktreeDest(rootDir, workspaceID, repoURL)))
-	if _, err := workspace.AddWithBranch(ctx, rootDir, workspaceID, repoURL, "", pr.HeadRef, baseRef, false); err != nil {
+	if _, err := workspace.AddWithTrackingBranch(ctx, rootDir, workspaceID, repoURL, "", pr.HeadRef, headRef, false); err != nil {
 		if rollbackErr := workspace.Remove(ctx, rootDir, workspaceID); rollbackErr != nil {
 			return fmt.Errorf("review failed: %w (rollback failed: %v)", err, rollbackErr)
 		}
@@ -1567,7 +1567,7 @@ func runCreateReviewPicker(ctx context.Context, rootDir string, noPrompt bool) e
 			break
 		}
 		description := pr.Title
-		workspaceID := fmt.Sprintf("REVIEW-PR-%d", num)
+		workspaceID := fmt.Sprintf("REVIEW-PR-%d-%s-%s", num, selectedRepo.Owner, selectedRepo.Repo)
 		output.Step(formatStep("create workspace", workspaceID, relPath(rootDir, filepath.Join(rootDir, "workspaces", workspaceID))))
 		wsDir, err := workspace.New(ctx, rootDir, workspaceID)
 		if err != nil {
@@ -1597,9 +1597,9 @@ func runCreateReviewPicker(ctx context.Context, rootDir string, noPrompt bool) e
 			break
 		}
 
-		baseRef := fmt.Sprintf("refs/remotes/origin/%s", pr.HeadRef)
+		headRef := fmt.Sprintf("refs/remotes/origin/%s", pr.HeadRef)
 		output.Step(formatStep("worktree add", displayRepoName(selectedRepo.RepoURL), worktreeDest(rootDir, workspaceID, selectedRepo.RepoURL)))
-		if _, err := workspace.AddWithBranch(ctx, rootDir, workspaceID, selectedRepo.RepoURL, "", pr.HeadRef, baseRef, false); err != nil {
+		if _, err := workspace.AddWithTrackingBranch(ctx, rootDir, workspaceID, selectedRepo.RepoURL, "", pr.HeadRef, headRef, false); err != nil {
 			if rollbackErr := workspace.Remove(ctx, rootDir, workspaceID); rollbackErr != nil {
 				failure = fmt.Errorf("review failed: %w (rollback failed: %v)", err, rollbackErr)
 			} else {
@@ -1826,7 +1826,7 @@ func runReview(ctx context.Context, rootDir string, args []string, noPrompt bool
 	if err != nil {
 		return err
 	}
-	workspaceID := fmt.Sprintf("REVIEW-PR-%d", req.Number)
+	workspaceID := fmt.Sprintf("REVIEW-PR-%d-%s-%s", req.Number, req.Owner, req.Repo)
 
 	theme := ui.DefaultTheme()
 	useColor := isatty.IsTerminal(os.Stdout.Fd())


### PR DESCRIPTION
## Summary
- use tracking local branches for review worktrees (origin/<head_ref>)
- include <owner>-<repo> suffix in review/issue default workspace IDs
- update create spec to match behavior

## Testing
- go test ./...