### PR TITLE
Prevent nested open and use GWS_WORKSPACE in prompt

### DIFF
--- a/docs/specs/open.md
+++ b/docs/specs/open.md
@@ -11,6 +11,7 @@ Open a workspace by launching an interactive subshell at the workspace root, mak
 
 ## Behavior
 - Accepts optional `WORKSPACE_ID`; if omitted, prompts the user to select a workspace.
+- Errors if `GWS_WORKSPACE` is already set (prevents nested `gws open`).
 - Resolves the workspace path as `<root>/workspaces/<WORKSPACE_ID>`.
 - Errors if the workspace does not exist.
 - Changes the gws process cwd to the workspace root.
@@ -53,6 +54,7 @@ Result
 
 ## Failure Modes
 - Missing workspace ID.
+- `GWS_WORKSPACE` already set (nested `gws open`).
 - Workspace directory not found.
 - Unable to determine or start the shell.
 - OS-level errors while changing directory or spawning the process.

--- a/internal/cli/open_test.go
+++ b/internal/cli/open_test.go
@@ -40,3 +40,15 @@ func TestShellCommandForOpenUnknown(t *testing.T) {
 		t.Fatalf("expected no args, got %v", args)
 	}
 }
+
+func TestNestedOpenWorkspaceID(t *testing.T) {
+	t.Setenv("GWS_WORKSPACE", "")
+	if got := nestedOpenWorkspaceID(); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+
+	t.Setenv("GWS_WORKSPACE", "ISSUE-38")
+	if got := nestedOpenWorkspaceID(); got != "ISSUE-38" {
+		t.Fatalf("expected ISSUE-38, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- block nested \`gws open\` when \`GWS_WORKSPACE\` is already set
- use \`GWS_WORKSPACE\` in the subshell prompt (fallback to the passed workspace id)
- document the nested-open failure mode

## Testing
- go test ./...