### PR TITLE
Hide gws open input banner

### DIFF
--- a/docs/specs/open.md
+++ b/docs/specs/open.md
@@ -36,11 +36,6 @@ Open a workspace by launching an interactive subshell at the workspace root, mak
 Example:
 
 ```
-Inputs
-  • workspace: ISSUE-19
-  • path: /path/to/gws/workspaces/ISSUE-19
-  • shell: /bin/zsh (interactive)
-
 Info
   • subshell; parent cwd unchanged
 

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -90,21 +90,12 @@ func runWorkspaceOpen(ctx context.Context, rootDir string, args []string, noProm
 	if len(cmdArgs) > 0 {
 		cmdDisplay = fmt.Sprintf("%s %s", cmdPath, strings.Join(cmdArgs, " "))
 	}
-	shellInfo := cmdPath
-	if len(cmdArgs) > 0 {
-		shellInfo = fmt.Sprintf("%s (interactive)", cmdPath)
-	}
 	theme := ui.DefaultTheme()
 	useColor := isatty.IsTerminal(os.Stdout.Fd())
 	renderer := ui.NewRenderer(os.Stdout, theme, useColor)
 	output.SetStepLogger(renderer)
 	defer output.SetStepLogger(nil)
 
-	renderer.Section("Inputs")
-	renderer.Bullet(fmt.Sprintf("workspace: %s", workspaceID))
-	renderer.Bullet(fmt.Sprintf("path: %s", wsDir))
-	renderer.Bullet(fmt.Sprintf("shell: %s", shellInfo))
-	renderer.Blank()
 	renderer.Section("Info")
 	renderer.Bullet("subshell; parent cwd unchanged")
 	renderer.Blank()


### PR DESCRIPTION
## Summary
- remove the redundant Inputs banner from `gws open` output
- keep the remaining Info/Steps/Result output unchanged
- update the `gws open` spec example accordingly

## Testing
- gofmt -w .
- go test ./...