### PR TITLE
Rename template new to add

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -24,7 +24,7 @@ Current command specs live in this folder:
 - `docs/specs/repo-get.md`
 - `docs/specs/repo-ls.md`
 - `docs/specs/template-ls.md`
-- `docs/specs/template-new.md`
+- `docs/specs/template-add.md`
 - `docs/specs/template-rm.md`
 - `docs/specs/resume.md`
 - `docs/specs/create.md`

--- a/docs/specs/create.md
+++ b/docs/specs/create.md
@@ -69,7 +69,7 @@ Same behavior as the former `gws review`.
   - `--no-prompt` with no URL => error.
   - Step 1: pick a repo from fetched bare stores whose origin remote is GitHub. Display `alias (owner/repo)`; filterable by substring.
   - Step 2: fetch open PRs for the repo via `gh api` (latest 50 open, sorted by updated desc).
-  - Step 3: multi-select PRs using the same add/remove loop as `gws template new` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
+- Step 3: multi-select PRs using the same add/remove loop as `gws template add` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
   - For each selected PR:
     - Workspace ID = `REVIEW-PR-<number>-<owner>-<repo>`.
     - Creates a local branch matching the PR head ref, tracking `origin/<head_ref>`.
@@ -114,7 +114,7 @@ Same behavior as the former `gws issue`.
   - `--no-prompt` with no URL => error.
   - Step 1: pick a repo from fetched bare stores whose origin remote resolves to a supported host. Display `alias (host/owner/repo)`; filterable by substring.
   - Step 2: fetch open issues for the chosen repo from the host API (GitHub via `gh api`; other hosts may be added later). Default fetch: latest 50 open issues sorted by updated desc.
-  - Step 3: multi-select issues using the same add/remove loop as `gws template new` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
+- Step 3: multi-select issues using the same add/remove loop as `gws template add` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
   - For each selected issue:
     - Workspace ID = `ISSUE-<number>-<owner>-<repo>` (no per-item override in this flow).
     - Branch defaults to `issue/<number>` and can be edited per issue in a list editor; duplicate branches must be re-entered.

--- a/docs/specs/template-add.md
+++ b/docs/specs/template-add.md
@@ -1,10 +1,10 @@
 ---
-title: "gws template new"
+title: "gws template add"
 status: implemented
 ---
 
 ## Synopsis
-`gws template new <name> [--repo <repo> ...]`
+`gws template add <name> [--repo <repo> ...]`
 
 ## Intent
 Create a template entry in `templates.yaml` without manual YAML editing, so users can quickly define the repo set for new workspaces.

--- a/docs/specs/template-rm.md
+++ b/docs/specs/template-rm.md
@@ -17,7 +17,7 @@ Remove one or more template definitions from `templates.yaml` without manual edi
   - Otherwise removes the listed templates and writes the file back via atomic tmp+rename.
 - With no names provided and prompts allowed:
   - Opens a filterable list of existing template names (case-insensitive substring match).
-  - UI behavior mirrors `gws template new` selection: the highlighted item is added on `<Enter>` and removed from the candidate list; a minimum of 1 selection is required.
+- UI behavior mirrors `gws template add` selection: the highlighted item is added on `<Enter>` and removed from the candidate list; a minimum of 1 selection is required.
   - Finish keys: `<Ctrl+D>` or typing `done` then `<Enter>`. If nothing selected, show an error and stay in the loop.
   - With `--no-prompt`, error instead of opening the selector.
 - After removal, other templates remain unchanged; repo stores are untouched.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -143,8 +143,8 @@ func runTemplate(ctx context.Context, rootDir string, args []string, noPrompt bo
 	switch args[0] {
 	case "ls":
 		return runTemplateList(ctx, rootDir, args[1:])
-	case "new":
-		return runTemplateNew(ctx, rootDir, args[1:], noPrompt)
+	case "add":
+		return runTemplateAdd(ctx, rootDir, args[1:], noPrompt)
 	default:
 		return fmt.Errorf("unknown template subcommand: %s", args[0])
 	}
@@ -222,34 +222,34 @@ func (b *boolFlag) IsBoolFlag() bool {
 	return true
 }
 
-func runTemplateNew(ctx context.Context, rootDir string, args []string, noPrompt bool) error {
-	newFlags := flag.NewFlagSet("template new", flag.ContinueOnError)
+func runTemplateAdd(ctx context.Context, rootDir string, args []string, noPrompt bool) error {
+	addFlags := flag.NewFlagSet("template add", flag.ContinueOnError)
 	var helpFlag bool
 	var repos stringSliceFlag
-	newFlags.Var(&repos, "repo", "repo spec (repeatable)")
-	newFlags.BoolVar(&helpFlag, "help", false, "show help")
-	newFlags.BoolVar(&helpFlag, "h", false, "show help")
-	newFlags.SetOutput(os.Stdout)
-	newFlags.Usage = func() {
-		printTemplateNewHelp(os.Stdout)
+	addFlags.Var(&repos, "repo", "repo spec (repeatable)")
+	addFlags.BoolVar(&helpFlag, "help", false, "show help")
+	addFlags.BoolVar(&helpFlag, "h", false, "show help")
+	addFlags.SetOutput(os.Stdout)
+	addFlags.Usage = func() {
+		printTemplateAddHelp(os.Stdout)
 	}
-	if err := newFlags.Parse(args); err != nil {
+	if err := addFlags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
 		}
 		return err
 	}
 	if helpFlag {
-		printTemplateNewHelp(os.Stdout)
+		printTemplateAddHelp(os.Stdout)
 		return nil
 	}
-	if newFlags.NArg() > 1 {
-		return fmt.Errorf("usage: gws template new [<name>] [--repo <repo> ...]")
+	if addFlags.NArg() > 1 {
+		return fmt.Errorf("usage: gws template add [<name>] [--repo <repo> ...]")
 	}
 
 	name := ""
-	if newFlags.NArg() == 1 {
-		name = newFlags.Arg(0)
+	if addFlags.NArg() == 1 {
+		name = addFlags.Arg(0)
 	}
 
 	file, err := template.Load(rootDir)
@@ -273,7 +273,7 @@ func runTemplateNew(ctx context.Context, rootDir string, args []string, noPrompt
 		if len(choices) == 0 {
 			return fmt.Errorf("no repos found; run gws repo get first")
 		}
-		name, repoSpecs, err = ui.PromptTemplateRepos("gws template new", name, choices, theme, useColor)
+		name, repoSpecs, err = ui.PromptTemplateRepos("gws template add", name, choices, theme, useColor)
 		if err != nil {
 			return err
 		}
@@ -283,7 +283,7 @@ func runTemplateNew(ctx context.Context, rootDir string, args []string, noPrompt
 			if noPrompt {
 				return fmt.Errorf("template name is required with --no-prompt")
 			}
-			name, err = ui.PromptTemplateName("gws template new", "", theme, useColor)
+			name, err = ui.PromptTemplateName("gws template add", "", theme, useColor)
 			if err != nil {
 				return err
 			}
@@ -300,7 +300,7 @@ func runTemplateNew(ctx context.Context, rootDir string, args []string, noPrompt
 				return fmt.Errorf("no repos found; run gws repo get first")
 			}
 			var selected []string
-			name, selected, err = ui.PromptTemplateRepos("gws template new", name, choices, theme, useColor)
+			name, selected, err = ui.PromptTemplateRepos("gws template add", name, choices, theme, useColor)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -26,7 +26,7 @@ func printGlobalHelp(w io.Writer) {
 	fmt.Fprintln(w, "  rm [<ID>]                          remove workspace (confirms on warnings)")
 	fmt.Fprintln(w, "  open [<ID>]                        open workspace in subshell")
 	fmt.Fprintln(w, "  repo <subcommand>                  repo commands (get/ls)")
-	fmt.Fprintln(w, "  template <subcommand>              template commands (ls)")
+	fmt.Fprintln(w, "  template <subcommand>              template commands (ls/add)")
 	fmt.Fprintln(w, "  doctor [--fix]                     check workspace/repo health")
 	fmt.Fprintln(w, "  init")
 	fmt.Fprintln(w, "  help [command]")
@@ -111,15 +111,15 @@ func printRepoLsHelp(w io.Writer) {
 
 func printTemplateHelp(w io.Writer) {
 	fmt.Fprintln(w, "Usage: gws template <subcommand>")
-	fmt.Fprintln(w, "  subcommands: ls, new")
+	fmt.Fprintln(w, "  subcommands: ls, add")
 }
 
 func printTemplateLsHelp(w io.Writer) {
 	fmt.Fprintln(w, "Usage: gws template ls")
 }
 
-func printTemplateNewHelp(w io.Writer) {
-	fmt.Fprintln(w, "Usage: gws template new [<name>] [--repo <repo> ...]")
+func printTemplateAddHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage: gws template add [<name>] [--repo <repo> ...]")
 	fmt.Fprintln(w, "  --repo <repo>  repo spec (repeatable)")
 }
 


### PR DESCRIPTION
## Summary
- rename gws template subcommand from new to add across CLI/help/specs
- update prompt labels to reflect the new subcommand
- align spec references in related docs

## Issue
- https://github.com/tasuku43/gws/issues/49
