### PR TITLE
Fix gws rm confirmations and forced worktree removal

### DIFF
--- a/docs/specs/rm.md
+++ b/docs/specs/rm.md
@@ -31,7 +31,7 @@ Safely remove a workspace and all of its worktrees, warning/confirming for risky
 - Calls `workspace.RemoveWithOptions`, which:
   - Validates the workspace exists.
   - With confirmation, allows dirty repos to be removed; otherwise fails if any repo has uncommitted/untracked/unstaged/unmerged changes.
-  - Runs `git worktree remove <worktree>` for each repo’s worktree.
+  - Runs `git worktree remove --force <worktree>` for dirty workspaces; otherwise runs `git worktree remove <worktree>` for each repo’s worktree.
   - Deletes the workspace directory.
 
 ## Success Criteria

--- a/internal/core/gitcmd/worktree.go
+++ b/internal/core/gitcmd/worktree.go
@@ -55,8 +55,12 @@ func WorktreeAddTrackingBranch(ctx context.Context, dir, branch, path, remoteNam
 }
 
 // WorktreeRemove removes a worktree.
-func WorktreeRemove(ctx context.Context, dir, path string) error {
-	res, err := Run(ctx, []string{"worktree", "remove", path}, Options{Dir: dir})
+func WorktreeRemove(ctx context.Context, dir, path string, force bool) error {
+	args := []string{"worktree", "remove", path}
+	if force {
+		args = []string{"worktree", "remove", "--force", path}
+	}
+	res, err := Run(ctx, args, Options{Dir: dir})
 	if err != nil {
 		if strings.TrimSpace(res.Stderr) != "" {
 			return fmt.Errorf("git worktree remove failed: %w: %s", err, strings.TrimSpace(res.Stderr))

--- a/internal/domain/workspace/remove.go
+++ b/internal/domain/workspace/remove.go
@@ -65,8 +65,13 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 		if repo.WorktreePath == "" {
 			return fmt.Errorf("missing worktree path for alias %q", repo.Alias)
 		}
-		gitcmd.Logf("git worktree remove %s", repo.WorktreePath)
-		if err := gitcmd.WorktreeRemove(ctx, repo.StorePath, repo.WorktreePath); err != nil {
+		force := opts.AllowDirty
+		if force {
+			gitcmd.Logf("git worktree remove --force %s", repo.WorktreePath)
+		} else {
+			gitcmd.Logf("git worktree remove %s", repo.WorktreePath)
+		}
+		if err := gitcmd.WorktreeRemove(ctx, repo.StorePath, repo.WorktreePath, force); err != nil {
 			return fmt.Errorf("remove worktree %q: %w", repo.Alias, err)
 		}
 	}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -2246,12 +2246,12 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceMultiSelectModel) View() string {
 	if m.stage == multiSelectStageConfirm {
 		frame := NewFrame(m.theme, m.useColor)
-		if len(m.confirmInputsRaw) > 0 {
-			frame.SetInputsRaw(m.confirmInputsRaw...)
-		}
 		label := promptLabel(m.theme, m.useColor, m.confirmModel.label)
 		line := fmt.Sprintf("%s (y/n): %s", label, m.confirmModel.input.View())
-		frame.AppendInputsPrompt(line)
+		frame.SetInputsPrompt(line)
+		if len(m.confirmInputsRaw) > 0 {
+			frame.AppendInputsRaw(m.confirmInputsRaw...)
+		}
 		return frame.Render()
 	}
 	frame := NewFrame(m.theme, m.useColor)
@@ -2301,7 +2301,7 @@ func (m workspaceMultiSelectModel) startConfirmIfNeeded() (workspaceMultiSelectM
 		return m, tea.Quit
 	}
 	m.confirmModel = newConfirmInlineModel(label, m.theme, m.useColor, false, nil, nil)
-	m.confirmInputsRaw = WorkspaceChoiceLines(m.filtered, -1, m.useColor, m.theme)
+	m.confirmInputsRaw = WorkspaceChoiceLines(m.selected, -1, m.useColor, m.theme)
 	m.stage = multiSelectStageConfirm
 	return m, nil
 }


### PR DESCRIPTION
## Summary
- avoid duplicate confirmation prompts for multi-select removal
- show selected workspace tree under confirmation prompt
- force git worktree remove when deleting dirty workspaces
- document forced removal behavior

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...