### PR TITLE
Add gws doctor --self environment diagnostics

### DIFF
--- a/docs/specs/doctor.md
+++ b/docs/specs/doctor.md
@@ -4,7 +4,7 @@ status: implemented
 ---
 
 ## Synopsis
-`gws doctor [--fix]`
+`gws doctor [--fix | --self]`
 
 ## Intent
 Detect common problems that block gws from working and surface them before users run other commands.
@@ -15,6 +15,10 @@ Detect common problems that block gws from working and surface them before users
 - Scans existing workspaces and aggregates any warnings emitted while inspecting their repositories (e.g., unreadable worktrees).
 - Lists repo stores and flags any store whose `origin` remote is missing or lacks a URL (`missing_remote`).
 - `--fix` currently performs the same checks and returns the list of issues; no automatic fixes are applied yet (the `fixed` list remains empty).
+- `--self` runs environment self-diagnostics and does not require an initialized root layout:
+  - Detects whether `git` is available on `PATH`.
+  - Reads `git version` and validates that the installed version meets the minimum (`2.20.0`).
+  - Emits OS-specific caveats (currently warns on Windows).
 
 ## Success Criteria
 - Command completes without errors; issues/warnings are printed for user action.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -27,7 +27,7 @@ func printGlobalHelp(w io.Writer) {
 	fmt.Fprintln(w, "  open [<ID>]                        open workspace in subshell")
 	fmt.Fprintln(w, "  repo <subcommand>                  repo commands (get/ls)")
 	fmt.Fprintln(w, "  template <subcommand>              template commands (ls/add)")
-	fmt.Fprintln(w, "  doctor [--fix]                     check workspace/repo health")
+	fmt.Fprintln(w, "  doctor [--fix | --self]            check workspace/repo health")
 	fmt.Fprintln(w, "  init")
 	fmt.Fprintln(w, "  help [command]")
 	fmt.Fprintln(w, "")
@@ -124,7 +124,8 @@ func printTemplateAddHelp(w io.Writer) {
 }
 
 func printDoctorHelp(w io.Writer) {
-	fmt.Fprintln(w, "Usage: gws doctor [--fix]")
+	fmt.Fprintln(w, "Usage: gws doctor [--fix | --self]")
+	fmt.Fprintln(w, "  --self            run self-diagnostics for the gws environment")
 }
 
 func printInitHelp(w io.Writer) {

--- a/internal/core/gitcmd/runner.go
+++ b/internal/core/gitcmd/runner.go
@@ -132,6 +132,7 @@ var allowedSubcommands = map[string]struct{}{
 	"status":           {},
 	"update-ref":       {},
 	"worktree":         {},
+	"version":          {},
 }
 
 func exitCode(err error) int {

--- a/internal/ops/doctor/self.go
+++ b/internal/ops/doctor/self.go
@@ -1,0 +1,143 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/tasuku43/gws/internal/core/gitcmd"
+)
+
+type SelfResult struct {
+	Issues   []Issue
+	Warnings []string
+	Details  []string
+}
+
+type gitVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+func (v gitVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}
+
+func (v gitVersion) Less(other gitVersion) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+	return v.patch < other.patch
+}
+
+var minGitVersion = gitVersion{major: 2, minor: 20, patch: 0}
+var gitVersionPattern = regexp.MustCompile(`\b(\d+)\.(\d+)(?:\.(\d+))?`)
+
+func SelfCheck(ctx context.Context) (SelfResult, error) {
+	result := SelfResult{
+		Details: []string{
+			fmt.Sprintf("os: %s/%s", runtime.GOOS, runtime.GOARCH),
+			fmt.Sprintf("minimum git version: %s", minGitVersion.String()),
+		},
+	}
+
+	result.Warnings = append(result.Warnings, osCaveats(runtime.GOOS)...)
+
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		result.Issues = append(result.Issues, Issue{
+			Kind:    "missing_dependency",
+			Message: "git not found in PATH",
+		})
+		result.Details = append(result.Details, "git: not found")
+		return result, nil
+	}
+	result.Details = append(result.Details, fmt.Sprintf("git path: %s", gitPath))
+
+	versionOutput, err := readGitVersion(ctx)
+	if err != nil {
+		result.Issues = append(result.Issues, Issue{
+			Kind:    "git_version_check_failed",
+			Message: err.Error(),
+		})
+		result.Details = append(result.Details, "git version: unknown")
+		return result, nil
+	}
+	result.Details = append(result.Details, fmt.Sprintf("git version: %s", versionOutput))
+
+	parsed, ok := parseGitVersion(versionOutput)
+	if !ok {
+		result.Issues = append(result.Issues, Issue{
+			Kind:    "invalid_git_version",
+			Message: fmt.Sprintf("unable to parse git version: %s", versionOutput),
+		})
+		return result, nil
+	}
+	if parsed.Less(minGitVersion) {
+		result.Issues = append(result.Issues, Issue{
+			Kind:    "git_version_too_old",
+			Message: fmt.Sprintf("git %s is older than required %s", parsed.String(), minGitVersion.String()),
+		})
+	}
+
+	return result, nil
+}
+
+func readGitVersion(ctx context.Context) (string, error) {
+	res, err := gitcmd.Run(ctx, []string{"version"}, gitcmd.Options{})
+	if err != nil {
+		if strings.TrimSpace(res.Stderr) != "" {
+			return "", fmt.Errorf("git version failed: %s", strings.TrimSpace(res.Stderr))
+		}
+		return "", fmt.Errorf("git version failed: %w", err)
+	}
+	out := strings.TrimSpace(res.Stdout)
+	if out == "" {
+		out = strings.TrimSpace(res.Stderr)
+	}
+	if out == "" {
+		return "", fmt.Errorf("git version returned no output")
+	}
+	return out, nil
+}
+
+func parseGitVersion(output string) (gitVersion, bool) {
+	matches := gitVersionPattern.FindStringSubmatch(output)
+	if len(matches) < 3 {
+		return gitVersion{}, false
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return gitVersion{}, false
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return gitVersion{}, false
+	}
+	patch := 0
+	if len(matches) > 3 && matches[3] != "" {
+		value, err := strconv.Atoi(matches[3])
+		if err != nil {
+			return gitVersion{}, false
+		}
+		patch = value
+	}
+	return gitVersion{major: major, minor: minor, patch: patch}, true
+}
+
+func osCaveats(goos string) []string {
+	switch strings.ToLower(strings.TrimSpace(goos)) {
+	case "windows":
+		return []string{"Windows detected: behavior may be limited; consider using WSL if issues occur."}
+	default:
+		return nil
+	}
+}

--- a/internal/ops/doctor/self_test.go
+++ b/internal/ops/doctor/self_test.go
@@ -1,0 +1,58 @@
+package doctor
+
+import "testing"
+
+func TestParseGitVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		input  string
+		want   gitVersion
+		wantOK bool
+	}{
+		{name: "standard", input: "git version 2.39.1", want: gitVersion{2, 39, 1}, wantOK: true},
+		{name: "apple", input: "git version 2.39.1 (Apple Git-143)", want: gitVersion{2, 39, 1}, wantOK: true},
+		{name: "windows", input: "git version 2.42.0.windows.1", want: gitVersion{2, 42, 0}, wantOK: true},
+		{name: "no patch", input: "git version 2.30", want: gitVersion{2, 30, 0}, wantOK: true},
+		{name: "invalid", input: "version unknown", wantOK: false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseGitVersion(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("ok mismatch: got %v want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("version mismatch: got %+v want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitVersionLess(t *testing.T) {
+	t.Parallel()
+	if !(gitVersion{major: 2, minor: 19, patch: 0}.Less(minGitVersion)) {
+		t.Fatalf("expected version to be less than minimum")
+	}
+	if (gitVersion{major: 2, minor: 20, patch: 0}.Less(minGitVersion)) {
+		t.Fatalf("expected version to meet minimum")
+	}
+	if (gitVersion{major: 3, minor: 0, patch: 0}.Less(minGitVersion)) {
+		t.Fatalf("expected version to exceed minimum")
+	}
+}
+
+func TestOsCaveats(t *testing.T) {
+	t.Parallel()
+	if len(osCaveats("windows")) == 0 {
+		t.Fatalf("expected windows caveat")
+	}
+	if len(osCaveats("darwin")) != 0 {
+		t.Fatalf("expected no caveat for darwin")
+	}
+}


### PR DESCRIPTION
## Summary
- add `gws doctor --self` for environment self-diagnostics
- check git availability and minimum version
- add OS caveat warnings and output details
- update doctor help/spec docs

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...

## Issue
- #50