### PR TITLE
Prefix repo info in review/issue workspace IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ gws opens an interactive subshell at the workspace root.
 gws create --review https://github.com/owner/repo/pull/123
 ```
 
-- Creates `REVIEW-PR-123`
+- Creates `OWNER-REPO-REVIEW-PR-123`
 - Fetches the PR head branch (forks not supported)
 - Requires `gh` authentication
 

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -18,7 +18,7 @@
 1. PR URL から `host/owner/repo` と番号を取得（GitHub: pull/<n>）
 2. repo store が未取得なら `repo get` と同等の導線で取得（対話）
 3. workspace を作成
-   - workspace ID は `REVIEW-PR-<number>` を使用（例: `REVIEW-PR-123`）
+   - workspace ID は `<OWNER>-<REPO>-REVIEW-PR-<number>` を使用（例: `OWNER-REPO-REVIEW-PR-123`）
 4. PR の head ref を fetch
    - `git fetch origin <head_ref>`
 5. fetch した ref を base に worktree を作成

--- a/docs/USECASES.md
+++ b/docs/USECASES.md
@@ -23,7 +23,7 @@ Rating legend:
 - **Check status** — `gws status <id>` shows dirty/untracked counts and HEAD per repo. Rating: Excellent (lightweight)
 
 ## Reviews
-- **Start a PR review** — `gws create --review <PR URL>` creates `REVIEW-PR-<num>`, fetches the PR head branch (forks not supported) for GitHub; requires `gh`. Rating: Good (GitHub only)
+- **Start a PR review** — `gws create --review <PR URL>` creates `<OWNER>-<REPO>-REVIEW-PR-<num>`, fetches the PR head branch (forks not supported) for GitHub; requires `gh`. Rating: Good (GitHub only)
 - **Add repos during review** — Use `gws add` after the review workspace is created. Rating: Good
 
 ## Cleanup / Maintenance

--- a/docs/specs/create.md
+++ b/docs/specs/create.md
@@ -59,10 +59,10 @@ Same behavior as the former `gws review`.
   - Saves the PR title as the workspace description.
   - Rejects forked PRs (head repo must match base repo).
   - Selects the repo URL based on `defaultRepoProtocol` (SSH preferred, HTTPS fallback).
-  - Workspace ID is `REVIEW-PR-<number>-<owner>-<repo>`; errors if it already exists.
+  - Workspace ID is `<OWNER>-<REPO>-REVIEW-PR-<number>` (owner/repo uppercased); errors if it already exists.
   - Ensures the repo store exists, prompting to run `gws repo get` if missing (unless `--no-prompt`, which fails instead).
   - Fetches the PR head ref into the bare store: `git fetch origin <head_ref>`.
-  - Adds a worktree under `<root>/workspaces/REVIEW-PR-<number>/<alias>` where:
+  - Adds a worktree under `<root>/workspaces/<OWNER>-<REPO>-REVIEW-PR-<number>/<alias>` where:
     - Creates a local branch `<head_ref>` tracking `origin/<head_ref>`.
     - Workspace metadata stores branch name as `<head_ref>`.
 - If `PR URL` is omitted and prompts are allowed (interactive picker):
@@ -71,7 +71,7 @@ Same behavior as the former `gws review`.
   - Step 2: fetch open PRs for the repo via `gh api` (latest 50 open, sorted by updated desc).
 - Step 3: multi-select PRs using the same add/remove loop as `gws template add` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
   - For each selected PR:
-    - Workspace ID = `REVIEW-PR-<number>-<owner>-<repo>`.
+    - Workspace ID = `<OWNER>-<REPO>-REVIEW-PR-<number>` (owner/repo uppercased).
     - Creates a local branch matching the PR head ref, tracking `origin/<head_ref>`.
     - Workspace metadata stores branch name as the PR head ref.
     - Workspace description = PR title.
@@ -81,7 +81,7 @@ Same behavior as the former `gws review`.
 - Output uses Inputs/Steps/Result only (no header line). When multiple workspaces are created, Result lists each workspace/worktree added.
 
 ### Success Criteria
-- For URL mode: new workspace `REVIEW-PR-<number>` exists with a worktree checked out to the PR head branch.
+- For URL mode: new workspace `<OWNER>-<REPO>-REVIEW-PR-<number>` exists with a worktree checked out to the PR head branch.
 - For picker mode: each selected PR produces a workspace with the same guarantees; partial success is reported if a later item fails.
 
 ### Failure Modes
@@ -98,7 +98,7 @@ Same behavior as the former `gws issue`.
 ### Behavior
 - If `ISSUE_URL` is provided:
   - Parse the URL to obtain `owner`, `repo`, and `issue number`.
-  - Workspace ID: defaults to `ISSUE-<number>-<owner>-<repo>`; can be overridden with `--workspace-id`. Must pass `git check-ref-format --branch`. If the workspace already exists, error.
+  - Workspace ID: defaults to `<OWNER>-<REPO>-ISSUE-<number>` (owner/repo uppercased); can be overridden with `--workspace-id`. Must pass `git check-ref-format --branch`. If the workspace already exists, error.
   - Branch: defaults to `issue/<number>`. Before proceeding, prompt the user with the default and allow editing unless `--no-prompt` or `--branch` is supplied.
   - For GitHub issues, uses `gh api` to fetch the issue title and saves it as the workspace description.
     - If the branch exists in the bare store, use it.
@@ -116,7 +116,7 @@ Same behavior as the former `gws issue`.
   - Step 2: fetch open issues for the chosen repo from the host API (GitHub via `gh api`; other hosts may be added later). Default fetch: latest 50 open issues sorted by updated desc.
 - Step 3: multi-select issues using the same add/remove loop as `gws template add` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
   - For each selected issue:
-    - Workspace ID = `ISSUE-<number>-<owner>-<repo>` (no per-item override in this flow).
+    - Workspace ID = `<OWNER>-<REPO>-ISSUE-<number>` (owner/repo uppercased, no per-item override in this flow).
     - Branch defaults to `issue/<number>` and can be edited per issue in a list editor; duplicate branches must be re-entered.
     - Workspace description = issue title.
     - Base ref detection and repo missing handling are the same as the URL path.
@@ -125,7 +125,7 @@ Same behavior as the former `gws issue`.
 - Output uses Inputs/Steps/Result (no header line). When multiple workspaces are created, Result lists each workspace/worktree added.
 
 ### Success Criteria
-- For URL mode: workspace `<root>/workspaces/ISSUE-<number>` exists with a worktree for the issue repo checked out to branch `issue/<number>`.
+- For URL mode: workspace `<root>/workspaces/<OWNER>-<REPO>-ISSUE-<number>` exists with a worktree for the issue repo checked out to branch `issue/<number>`.
 - For picker mode: each selected issue produces a workspace with the same guarantees; partial success is reported if a later item fails.
 
 ### Failure Modes

--- a/docs/specs/open.md
+++ b/docs/specs/open.md
@@ -41,7 +41,7 @@ Info
 
 Steps
   • chdir
-    └─ /path/to/gws/workspaces/ISSUE-19
+    └─ /path/to/gws/workspaces/OWNER-REPO-ISSUE-19
   • launch subshell
     └─ /bin/zsh -i
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -920,7 +920,7 @@ func runCreateIssue(ctx context.Context, rootDir, issueURL, workspaceID, branch,
 
 	branchProvided := branch != ""
 	if workspaceID == "" {
-		workspaceID = fmt.Sprintf("ISSUE-%d-%s-%s", req.Number, req.Owner, req.Repo)
+		workspaceID = formatIssueWorkspaceID(req.Owner, req.Repo, req.Number)
 	}
 	if branch == "" {
 		branch = fmt.Sprintf("issue/%d", req.Number)
@@ -1065,7 +1065,7 @@ func runIssue(ctx context.Context, rootDir string, args []string, noPrompt bool)
 
 	branchProvided := branch != ""
 	if workspaceID == "" {
-		workspaceID = fmt.Sprintf("ISSUE-%d-%s-%s", req.Number, req.Owner, req.Repo)
+		workspaceID = formatIssueWorkspaceID(req.Owner, req.Repo, req.Number)
 	}
 	if branch == "" {
 		branch = fmt.Sprintf("issue/%d", req.Number)
@@ -1258,7 +1258,7 @@ func runIssuePicker(ctx context.Context, rootDir string, noPrompt bool, title st
 		if issue, ok := issueByNumber[num]; ok {
 			description = issue.Title
 		}
-		workspaceID := fmt.Sprintf("ISSUE-%d-%s-%s", num, selectedRepo.Owner, selectedRepo.Repo)
+		workspaceID := formatIssueWorkspaceID(selectedRepo.Owner, selectedRepo.Repo, num)
 		branch := strings.TrimSpace(selection.Branch)
 		if branch == "" {
 			branch = fmt.Sprintf("issue/%d", num)
@@ -1388,7 +1388,7 @@ func runCreateIssueSelected(ctx context.Context, rootDir string, noPrompt bool, 
 		if issue, ok := issueByNumber[num]; ok {
 			description = issue.Title
 		}
-		workspaceID := fmt.Sprintf("ISSUE-%d-%s-%s", num, selectedRepo.Owner, selectedRepo.Repo)
+		workspaceID := formatIssueWorkspaceID(selectedRepo.Owner, selectedRepo.Repo, num)
 		branch := strings.TrimSpace(selection.Branch)
 		if branch == "" {
 			branch = fmt.Sprintf("issue/%d", num)
@@ -1701,7 +1701,7 @@ func runCreateReview(ctx context.Context, rootDir, prURL string, noPrompt bool) 
 		}
 	}
 
-	workspaceID := fmt.Sprintf("REVIEW-PR-%d-%s-%s", pr.Number, baseOwner, baseRepo)
+	workspaceID := formatReviewWorkspaceID(baseOwner, baseRepo, pr.Number)
 	output.Step(formatStep("create workspace", workspaceID, relPath(rootDir, workspace.WorkspaceDir(rootDir, workspaceID))))
 	wsDir, err := workspace.New(ctx, rootDir, workspaceID)
 	if err != nil {
@@ -1841,7 +1841,7 @@ func runCreateReviewPicker(ctx context.Context, rootDir string, noPrompt bool) e
 			break
 		}
 		description := pr.Title
-		workspaceID := fmt.Sprintf("REVIEW-PR-%d-%s-%s", num, selectedRepo.Owner, selectedRepo.Repo)
+		workspaceID := formatReviewWorkspaceID(selectedRepo.Owner, selectedRepo.Repo, num)
 		output.Step(formatStep("create workspace", workspaceID, relPath(rootDir, workspace.WorkspaceDir(rootDir, workspaceID))))
 		wsDir, err := workspace.New(ctx, rootDir, workspaceID)
 		if err != nil {
@@ -1979,7 +1979,7 @@ func runCreateReviewSelected(ctx context.Context, rootDir string, noPrompt bool,
 			break
 		}
 		description := pr.Title
-		workspaceID := fmt.Sprintf("REVIEW-PR-%d-%s-%s", num, selectedRepo.Owner, selectedRepo.Repo)
+		workspaceID := formatReviewWorkspaceID(selectedRepo.Owner, selectedRepo.Repo, num)
 		output.Step(formatStep("create workspace", workspaceID, relPath(rootDir, workspace.WorkspaceDir(rootDir, workspaceID))))
 		wsDir, err := workspace.New(ctx, rootDir, workspaceID)
 		if err != nil {
@@ -2191,6 +2191,14 @@ func splitRepoFullName(fullName string) (string, string, bool) {
 	return parts[0], parts[1], true
 }
 
+func formatReviewWorkspaceID(owner, repo string, number int) string {
+	return fmt.Sprintf("%s-%s-REVIEW-PR-%d", strings.ToUpper(strings.TrimSpace(owner)), strings.ToUpper(strings.TrimSpace(repo)), number)
+}
+
+func formatIssueWorkspaceID(owner, repo string, number int) string {
+	return fmt.Sprintf("%s-%s-ISSUE-%d", strings.ToUpper(strings.TrimSpace(owner)), strings.ToUpper(strings.TrimSpace(repo)), number)
+}
+
 func fetchPRHead(ctx context.Context, storePath, headRef string) error {
 	if strings.TrimSpace(storePath) == "" {
 		return fmt.Errorf("store path is required")
@@ -2321,7 +2329,7 @@ func runReview(ctx context.Context, rootDir string, args []string, noPrompt bool
 	if err != nil {
 		return err
 	}
-	workspaceID := fmt.Sprintf("REVIEW-PR-%d-%s-%s", req.Number, req.Owner, req.Repo)
+	workspaceID := formatReviewWorkspaceID(req.Owner, req.Repo, req.Number)
 
 	theme := ui.DefaultTheme()
 	useColor := isatty.IsTerminal(os.Stdout.Fd())

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import "testing"
+
+func TestFormatReviewWorkspaceID(t *testing.T) {
+	cases := []struct {
+		name   string
+		owner  string
+		repo   string
+		number int
+		want   string
+	}{
+		{
+			name:   "basic",
+			owner:  "owner",
+			repo:   "repo",
+			number: 123,
+			want:   "OWNER-REPO-REVIEW-PR-123",
+		},
+		{
+			name:   "trim and uppercase",
+			owner:  "  MiXeD ",
+			repo:   "  rEpO-name ",
+			number: 9,
+			want:   "MIXED-REPO-NAME-REVIEW-PR-9",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatReviewWorkspaceID(tc.owner, tc.repo, tc.number); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatIssueWorkspaceID(t *testing.T) {
+	cases := []struct {
+		name   string
+		owner  string
+		repo   string
+		number int
+		want   string
+	}{
+		{
+			name:   "basic",
+			owner:  "owner",
+			repo:   "repo",
+			number: 456,
+			want:   "OWNER-REPO-ISSUE-456",
+		},
+		{
+			name:   "trim and uppercase",
+			owner:  "  MiXeD ",
+			repo:   "  rEpO-name ",
+			number: 1,
+			want:   "MIXED-REPO-NAME-ISSUE-1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatIssueWorkspaceID(tc.owner, tc.repo, tc.number); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Move repo info to prefix and uppercase for review/issue workspace IDs
- Centralize ID formatting in create flow
- Update docs/specs/examples to match new ID format

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...