### PR TITLE
Show workspace warnings in gws ls

### DIFF
--- a/docs/specs/ls.md
+++ b/docs/specs/ls.md
@@ -15,6 +15,7 @@ List workspaces under `<root>/workspaces` and show a quick view of the repos att
 - Scans `<root>/workspaces` for directories; ignores non-directories.
 - For each workspace, scans its contents to discover repo worktrees (alias, repo key, branch, path) and renders them in a tree view.
 - If a workspace description is available, show it alongside the workspace ID.
+- If a workspace has status warnings (dirty, unpushed, diverged, unknown), show an inline tag next to the workspace ID (same labels as `gws rm`).
 - Collects and reports non-fatal warnings from scanning workspaces or repos.
 - `--search <query>`: prefilters the list using case-insensitive substring match against workspace ID and repo aliases/paths. Applies to both normal and selection mode.
 - `--select`: launches an interactive TUI picker (requires TTY; errors under `--no-prompt`) that lists the filtered workspaces with live search. On `<Enter>`, returns the selected workspace ID to stdout (single line, no sections) and exits 0. If nothing to select, returns an error.


### PR DESCRIPTION
## Summary
- show workspace warning tags in `gws ls` output
- reuse workspace choice rendering to align list output with `gws rm`
- document warning tags in `docs/specs/ls.md`

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...

## Issue
- #60