### PR TITLE
Fix selection list scrolling in prompts

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -81,6 +81,7 @@ Steps
 - Select/confirm: Bubbles list or simple radio
 - Spinners: optional; use subtle style only
 - Help line: muted color, minimal content
+- Long selection lists should scroll so Inputs stay visible.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Make selection lists scroll by window height so Inputs remain visible
- Add fallback height when WindowSizeMsg is not available
- Document scrolling behavior in UI spec

## Test
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...

Fixes #63