### PR TITLE
Support gws create --repo <repo>

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ gws repo get git@github.com:octocat/Spoon-Knife.git
 gws create --template example MY-123
 ```
 
+Or create from a single repo:
+
+```bash
+gws create --repo git@github.com:octocat/Hello-World.git
+```
+
 Or run `gws create` with no args to pick a mode and fill inputs interactively.
 
 ### 5) Work and clean up
@@ -108,6 +114,7 @@ Core workflow:
 - `gws repo ls` - list repos already fetched
 - `gws template ls` - list templates from `templates.yaml`
 - `gws create --template <name> [<id>]` - create a workspace from a template
+- `gws create --repo [<repo>]` - create a workspace from a repo (prompts for id)
 - `gws add [<id>] [<repo>]` - add another repo worktree to a workspace
 - `gws ls` - list workspaces and repos
 - `gws open [<id>]` - open a workspace in an interactive subshell

--- a/docs/specs/create.md
+++ b/docs/specs/create.md
@@ -4,7 +4,7 @@ status: implemented
 ---
 
 ## Synopsis
-`gws create [--template <name> | --review [<PR URL>] | --issue [<ISSUE_URL>] | --repo] [<WORKSPACE_ID>] [--workspace-id <id>] [--branch <name>] [--base <ref>] [--no-prompt]`
+`gws create [--template <name> | --review [<PR URL>] | --issue [<ISSUE_URL>] | --repo [<repo>]] [<WORKSPACE_ID>] [--workspace-id <id>] [--branch <name>] [--base <ref>] [--no-prompt]`
 
 ## Intent
 Unify all workspace creation flows under a single command and keep "create" semantics consistent across modes.
@@ -53,8 +53,9 @@ Same behavior as the former `gws new`.
 Create a workspace from a selected repo without using a template.
 
 ### Behavior
-- Requires prompts/TTY to select repos.
-- Step 1: select a repo (searchable single-select) from existing repo stores.
+- If `<repo>` is provided, use it directly and skip repo selection.
+- Without `<repo>`, requires prompts/TTY to select a repo.
+- Step 1 (selection path only): select a repo (searchable single-select) from existing repo stores.
 - Step 2: same flow as template mode after selection:
   - Decide the workspace ID.
   - Input an optional description.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -70,11 +70,11 @@ func printCommandHelp(cmd string, w io.Writer) bool {
 }
 
 func printCreateHelp(w io.Writer) {
-	fmt.Fprintln(w, "Usage: gws create [--template <name> | --review [<PR URL>] | --issue [<ISSUE_URL>] | --repo] [<WORKSPACE_ID>] [--workspace-id <id>] [--branch <name>] [--base <ref>] [--no-prompt]")
+	fmt.Fprintln(w, "Usage: gws create [--template <name> | --review [<PR URL>] | --issue [<ISSUE_URL>] | --repo [<repo>]] [<WORKSPACE_ID>] [--workspace-id <id>] [--branch <name>] [--base <ref>] [--no-prompt]")
 	fmt.Fprintln(w, "  --template <name>  template name")
 	fmt.Fprintln(w, "  --review           create review workspace from PR")
 	fmt.Fprintln(w, "  --issue            create issue workspace from issue")
-	fmt.Fprintln(w, "  --repo             create workspace by selecting repos")
+	fmt.Fprintln(w, "  --repo [<repo>]    create workspace from a repo (optional interactive selection)")
 }
 
 func printAddHelp(w io.Writer) {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -227,7 +227,7 @@ type createFlowModel struct {
 	useColor bool
 }
 
-func newCreateFlowModel(title string, templates []string, tmplErr error, repoChoices []PromptChoice, repoErr error, defaultWorkspaceID string, reviewRepos []PromptChoice, issueRepos []PromptChoice, loadReview func(string) ([]PromptChoice, error), loadIssue func(string) ([]PromptChoice, error), loadTemplateRepos func(string) ([]string, error), validateBranch func(string) error, theme Theme, useColor bool, startMode string) createFlowModel {
+func newCreateFlowModel(title string, templates []string, tmplErr error, repoChoices []PromptChoice, repoErr error, defaultWorkspaceID string, reviewRepos []PromptChoice, issueRepos []PromptChoice, loadReview func(string) ([]PromptChoice, error), loadIssue func(string) ([]PromptChoice, error), loadTemplateRepos func(string) ([]string, error), validateBranch func(string) error, theme Theme, useColor bool, startMode string, selectedRepo string) createFlowModel {
 	input := textinput.New()
 	input.Prompt = ""
 	input.Placeholder = "search"
@@ -252,8 +252,16 @@ func newCreateFlowModel(title string, templates []string, tmplErr error, repoCho
 		theme:              theme,
 		useColor:           useColor,
 	}
+	m.repoSelected = strings.TrimSpace(selectedRepo)
 	if strings.TrimSpace(startMode) != "" {
-		m.startMode(startMode)
+		if startMode == "repo" && m.repoSelected != "" {
+			m.mode = "repo"
+			m.templateRepos = []string{m.repoSelected}
+			m.templateModel = newInputsModelWithLabel("gws create", nil, m.repoSelected, m.defaultWorkspaceID, "repo", m.theme, m.useColor)
+			m.stage = createStageRepoWorkspace
+		} else {
+			m.startMode(startMode)
+		}
 	}
 	if m.stage == createStageMode {
 		m.filtered = m.filterModes()
@@ -1196,8 +1204,8 @@ func PromptIssueSelectWithBranches(title, label string, choices []PromptChoice, 
 	return append([]IssueSelection(nil), final.selectedIssues...), nil
 }
 
-func PromptCreateFlow(title string, startMode string, defaultWorkspaceID string, templates []string, templateErr error, repoChoices []PromptChoice, repoErr error, reviewRepos []PromptChoice, issueRepos []PromptChoice, loadReview func(string) ([]PromptChoice, error), loadIssue func(string) ([]PromptChoice, error), loadTemplateRepos func(string) ([]string, error), validateBranch func(string) error, theme Theme, useColor bool) (string, string, string, string, []string, string, []string, string, []IssueSelection, string, error) {
-	model := newCreateFlowModel(title, templates, templateErr, repoChoices, repoErr, defaultWorkspaceID, reviewRepos, issueRepos, loadReview, loadIssue, loadTemplateRepos, validateBranch, theme, useColor, startMode)
+func PromptCreateFlow(title string, startMode string, defaultWorkspaceID string, templates []string, templateErr error, repoChoices []PromptChoice, repoErr error, reviewRepos []PromptChoice, issueRepos []PromptChoice, loadReview func(string) ([]PromptChoice, error), loadIssue func(string) ([]PromptChoice, error), loadTemplateRepos func(string) ([]string, error), validateBranch func(string) error, theme Theme, useColor bool, selectedRepo string) (string, string, string, string, []string, string, []string, string, []IssueSelection, string, error) {
+	model := newCreateFlowModel(title, templates, templateErr, repoChoices, repoErr, defaultWorkspaceID, reviewRepos, issueRepos, loadReview, loadIssue, loadTemplateRepos, validateBranch, theme, useColor, startMode, selectedRepo)
 	if model.err != nil {
 		return "", "", "", "", nil, "", nil, "", nil, "", model.err
 	}


### PR DESCRIPTION
## Summary
- allow `gws create --repo <repo>` to skip repo selection
- keep repo flow inputs in a single TUI session
- update create help/spec/README

## Testing
- go test ./...
- go vet ./...
- go build ./...