### PR TITLE
Improve issue branch input layout

### DIFF
--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1784,7 +1784,8 @@ func renderIssueBranchEditFrame(model issueBranchSelectModel, headerLines ...str
 				}
 				branchDisplay = model.branchInputs[i].View()
 			}
-			b.WriteString(fmt.Sprintf("%s%s %s | branch: %s\n", output.Indent+output.Indent, mutedToken(model.theme, model.useColor, output.LogConnector), display, branchDisplay))
+			b.WriteString(fmt.Sprintf("%s%s %s\n", output.Indent+output.Indent, mutedToken(model.theme, model.useColor, output.LogConnector), display))
+			b.WriteString(fmt.Sprintf("%s%s  branch: %s\n", output.Indent+output.Indent+output.Indent, mutedToken(model.theme, model.useColor, output.LogConnector), branchDisplay))
 		}
 	})
 	frame.AppendInputsRaw(rawLines...)


### PR DESCRIPTION
## Summary
- split issue/branch display into two lines to avoid wide rows in `gws create` issue selection

## Testing
- go test ./...
- go vet ./...
- go build ./...