### PR TITLE
Fix repeated Inputs in create flows

### DIFF
--- a/docs/specs/create.md
+++ b/docs/specs/create.md
@@ -14,6 +14,7 @@ Unify all workspace creation flows under a single command and keep "create" sema
 - If none are provided and prompts are allowed, enter an interactive mode picker.
   - The picker presents `template`, `repo`, `review`, `issue` and supports arrow selection with filterable search.
 - If none are provided and `--no-prompt` is set, error.
+- When prompts are used, mode flags (`--template`, `--review`, `--issue`, `--repo`) still run the unified create prompt flow so the Inputs section is rendered as a single in-place interaction.
 
 ## Mode: template
 Same behavior as the former `gws new`.


### PR DESCRIPTION
## Summary
- unify create prompts to avoid repeated Inputs sections for template/review/issue flows
- route template/review/issue pickers through the shared create flow
- document unified prompt behavior in the create spec

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...