### PR TITLE
Add template validate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ templates:
       - git@github.com:octocat/Spoon-Knife.git
 ```
 
+Validate the file:
+
+```bash
+gws template validate
+```
+
 ### 3) Fetch repos (bare store)
 
 ```bash
@@ -110,6 +116,7 @@ Core workflow:
 - `gws repo get <repo>` - create/update bare repo store
 - `gws repo ls` - list repos already fetched
 - `gws template ls` - list templates from `templates.yaml`
+- `gws template validate` - validate `templates.yaml` entries
 - `gws create --template <name> [<id>]` - create a workspace from a template
 - `gws create --repo [<repo>]` - create a workspace from a repo (prompts for id)
 - `gws add [<id>] [<repo>]` - add another repo worktree to a workspace

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -22,6 +22,7 @@ templates:
 - `gws create --template <name>` でテンプレート名を指定（未指定なら対話）
 - repo は `gws repo get` 済みであることが前提（未取得ならエラー）
 - テンプレートの編集は `templates.yaml` を直接編集する
+- 編集後は `gws template validate` で整合性を確認する
 
 repo get の補助:
 - 未取得 repo がある場合は `gws create --template` が対話で `repo get` を実行するか確認する

--- a/docs/USECASES.md
+++ b/docs/USECASES.md
@@ -12,7 +12,7 @@ Rating legend:
 
 ## Setup / Preparation
 - **Initialize root** — `gws init` creates bare/workspaces and `templates.yaml` in one shot. Once per environment. Rating: Excellent
-- **Define / check templates** — Edit `templates.yaml` directly, confirm names with `gws template ls`. Rating: Good (manual YAML editing, no validation)
+- **Define / check templates** — Edit `templates.yaml` directly, confirm names with `gws template ls`, validate with `gws template validate`. Rating: Good
 - **Fetch repositories** — `gws repo get <repo>` creates bare store; `gws repo ls` lists fetched repos. Rating: Good (does not fetch when bare already exists, so not ideal for updating)
 - **Switch roots** — Use `--root` or `GWS_ROOT` to separate environments. Rating: Excellent
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -26,6 +26,7 @@ Current command specs live in this folder:
 - `docs/specs/template-ls.md`
 - `docs/specs/template-add.md`
 - `docs/specs/template-rm.md`
+- `docs/specs/template-validate.md`
 - `docs/specs/resume.md`
 - `docs/specs/create.md`
 - `docs/specs/add.md`

--- a/docs/specs/template-validate.md
+++ b/docs/specs/template-validate.md
@@ -1,0 +1,29 @@
+---
+title: "gws template validate"
+status: implemented
+---
+
+## Synopsis
+`gws template validate`
+
+## Intent
+Validate `templates.yaml` to catch malformed templates before use.
+
+## Behavior
+- Loads `<root>/templates.yaml`; missing or unreadable file is reported as an issue.
+- Parses YAML and reports errors if invalid.
+- Checks for required fields:
+  - top-level `templates` mapping exists.
+  - each template entry includes a non-empty `repos` list.
+- Detects duplicate template names in the YAML source.
+- Validates template names using the same rules as `gws template add`.
+- Validates each repo spec via the existing repo spec normalization rules.
+- Output uses the standard “Result” section with one bullet per issue; when no issues are found, prints “no issues found”.
+
+## Success Criteria
+- Returns success when `templates.yaml` is valid.
+
+## Failure Modes
+- `templates.yaml` missing/unreadable.
+- YAML parse error.
+- Missing required fields, duplicate template names, invalid template names, or invalid repo specs.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -27,7 +27,7 @@ func printGlobalHelp(w io.Writer) {
 	fmt.Fprintln(w, "  open [<ID>]                        open workspace in subshell")
 	fmt.Fprintln(w, "  path --workspace                   print selected workspace path")
 	fmt.Fprintln(w, "  repo <subcommand>                  repo commands (get/ls)")
-	fmt.Fprintln(w, "  template <subcommand>              template commands (ls/add/rm)")
+	fmt.Fprintln(w, "  template <subcommand>              template commands (ls/add/rm/validate)")
 	fmt.Fprintln(w, "  doctor [--fix | --self]            check workspace/repo health")
 	fmt.Fprintln(w, "  init")
 	fmt.Fprintln(w, "  help [command]")
@@ -120,7 +120,7 @@ func printRepoLsHelp(w io.Writer) {
 
 func printTemplateHelp(w io.Writer) {
 	fmt.Fprintln(w, "Usage: gws template <subcommand>")
-	fmt.Fprintln(w, "  subcommands: ls, add, rm")
+	fmt.Fprintln(w, "  subcommands: ls, add, rm, validate")
 }
 
 func printTemplateLsHelp(w io.Writer) {
@@ -134,6 +134,10 @@ func printTemplateAddHelp(w io.Writer) {
 
 func printTemplateRmHelp(w io.Writer) {
 	fmt.Fprintln(w, "Usage: gws template rm [<name> ...]")
+}
+
+func printTemplateValidateHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage: gws template validate")
 }
 
 func printDoctorHelp(w io.Writer) {

--- a/internal/domain/template/validate.go
+++ b/internal/domain/template/validate.go
@@ -1,0 +1,198 @@
+package template
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tasuku43/gws/internal/domain/repo"
+	"gopkg.in/yaml.v3"
+)
+
+type ValidationIssue struct {
+	Kind     string
+	Template string
+	Repo     string
+	Message  string
+}
+
+type ValidationResult struct {
+	Path   string
+	Issues []ValidationIssue
+}
+
+const (
+	IssueKindFile                = "templates.yaml"
+	IssueKindInvalidYAML         = "invalid yaml"
+	IssueKindMissingRequired     = "missing required field"
+	IssueKindDuplicateTemplate   = "duplicate template name"
+	IssueKindInvalidTemplateName = "invalid template name"
+	IssueKindInvalidRepoSpec     = "invalid repo spec"
+)
+
+func Validate(rootDir string) (ValidationResult, error) {
+	if strings.TrimSpace(rootDir) == "" {
+		return ValidationResult{}, fmt.Errorf("root directory is required")
+	}
+	path := filepath.Join(rootDir, FileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ValidationResult{
+			Path:   path,
+			Issues: []ValidationIssue{joinFileIssue(err)},
+		}, nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return ValidationResult{
+			Path:   path,
+			Issues: []ValidationIssue{joinIssue(IssueKindInvalidYAML, "", "", err.Error())},
+		}, nil
+	}
+
+	root := unwrapDocument(&doc)
+	issues := validateRootTemplates(root)
+	return ValidationResult{Path: path, Issues: issues}, nil
+}
+
+func unwrapDocument(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return node
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return node.Content[0]
+	}
+	return node
+}
+
+func validateRootTemplates(root *yaml.Node) []ValidationIssue {
+	if root == nil || root.Kind != yaml.MappingNode {
+		return []ValidationIssue{joinIssue(IssueKindMissingRequired, "", "", "templates")}
+	}
+	var templatesNode *yaml.Node
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		key := root.Content[i]
+		value := root.Content[i+1]
+		if key != nil && key.Value == "templates" {
+			templatesNode = value
+			break
+		}
+	}
+	if templatesNode == nil {
+		return []ValidationIssue{joinIssue(IssueKindMissingRequired, "", "", "templates")}
+	}
+	if templatesNode.Kind != yaml.MappingNode {
+		return []ValidationIssue{joinIssue(IssueKindMissingRequired, "", "", "templates must be a mapping")}
+	}
+
+	return validateTemplatesMap(templatesNode)
+}
+
+func validateTemplatesMap(node *yaml.Node) []ValidationIssue {
+	var issues []ValidationIssue
+	seen := make(map[string]struct{})
+
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		name := ""
+		if key != nil {
+			name = strings.TrimSpace(key.Value)
+		}
+		if err := ValidateName(name); err != nil {
+			issues = append(issues, joinIssue(IssueKindInvalidTemplateName, name, "", err.Error()))
+		}
+		if name != "" {
+			if _, ok := seen[name]; ok {
+				issues = append(issues, joinIssue(IssueKindDuplicateTemplate, name, "", "duplicate template name"))
+			} else {
+				seen[name] = struct{}{}
+			}
+		}
+		issues = append(issues, validateTemplateEntry(name, value)...)
+	}
+	return issues
+}
+
+func validateTemplateEntry(name string, node *yaml.Node) []ValidationIssue {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return []ValidationIssue{joinIssue(IssueKindMissingRequired, name, "", "template entry must be a mapping")}
+	}
+	var reposNode *yaml.Node
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key != nil && key.Value == "repos" {
+			reposNode = value
+			break
+		}
+	}
+	if reposNode == nil {
+		return []ValidationIssue{joinIssue(IssueKindMissingRequired, name, "", "repos")}
+	}
+	if reposNode.Kind != yaml.SequenceNode {
+		return []ValidationIssue{joinIssue(IssueKindMissingRequired, name, "", "repos must be a list")}
+	}
+
+	var issues []ValidationIssue
+	var foundRepo bool
+	for _, entry := range reposNode.Content {
+		repoSpec, ok := repoFromNode(entry)
+		if !ok {
+			issues = append(issues, joinIssue(IssueKindInvalidRepoSpec, name, "", "repo entry must be a string or {repo: ...}"))
+			continue
+		}
+		trimmed := strings.TrimSpace(repoSpec)
+		if trimmed == "" {
+			issues = append(issues, joinIssue(IssueKindInvalidRepoSpec, name, "", "repo spec is empty"))
+			continue
+		}
+		foundRepo = true
+		if _, _, err := repo.Normalize(trimmed); err != nil {
+			issues = append(issues, joinIssue(IssueKindInvalidRepoSpec, name, trimmed, err.Error()))
+		}
+	}
+	if !foundRepo && len(issues) == 0 {
+		issues = append(issues, joinIssue(IssueKindMissingRequired, name, "", "repos"))
+	}
+	return issues
+}
+
+func repoFromNode(node *yaml.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	if node.Kind == yaml.ScalarNode {
+		return node.Value, true
+	}
+	if node.Kind != yaml.MappingNode {
+		return "", false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key != nil && key.Value == "repo" && value != nil && value.Kind == yaml.ScalarNode {
+			return value.Value, true
+		}
+	}
+	return "", false
+}
+
+func joinFileIssue(err error) ValidationIssue {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	return joinIssue(IssueKindFile, "", "", message)
+}
+
+func joinIssue(kind, templateName, repoSpec, message string) ValidationIssue {
+	return ValidationIssue{
+		Kind:     kind,
+		Template: strings.TrimSpace(templateName),
+		Repo:     strings.TrimSpace(repoSpec),
+		Message:  strings.TrimSpace(message),
+	}
+}

--- a/internal/domain/template/validate_test.go
+++ b/internal/domain/template/validate_test.go
@@ -1,0 +1,137 @@
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateTemplatesOK(t *testing.T) {
+	rootDir := t.TempDir()
+	data := []byte(`templates:
+  app:
+    repos:
+      - git@github.com:org/app.git
+  legacy:
+    repos:
+      - repo: git@github.com:org/legacy.git
+`)
+	path := filepath.Join(rootDir, FileName)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write templates: %v", err)
+	}
+	result, err := Validate(rootDir)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(result.Issues) != 0 {
+		t.Fatalf("expected no issues, got %d", len(result.Issues))
+	}
+}
+
+func TestValidateTemplatesDuplicate(t *testing.T) {
+	rootDir := t.TempDir()
+	data := []byte(`templates:
+  app:
+    repos:
+      - git@github.com:org/app.git
+  app:
+    repos:
+      - git@github.com:org/other.git
+`)
+	path := filepath.Join(rootDir, FileName)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write templates: %v", err)
+	}
+	result, err := Validate(rootDir)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !hasIssueKind(result.Issues, IssueKindDuplicateTemplate) {
+		t.Fatalf("expected duplicate template issue")
+	}
+}
+
+func TestValidateTemplatesMissingRepos(t *testing.T) {
+	rootDir := t.TempDir()
+	data := []byte(`templates:
+  app:
+    description: test
+`)
+	path := filepath.Join(rootDir, FileName)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write templates: %v", err)
+	}
+	result, err := Validate(rootDir)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !hasIssueKind(result.Issues, IssueKindMissingRequired) {
+		t.Fatalf("expected missing required field issue")
+	}
+}
+
+func TestValidateTemplatesInvalidRepo(t *testing.T) {
+	rootDir := t.TempDir()
+	data := []byte(`templates:
+  app:
+    repos:
+      - github.com/org/app
+`)
+	path := filepath.Join(rootDir, FileName)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write templates: %v", err)
+	}
+	result, err := Validate(rootDir)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !hasIssueKind(result.Issues, IssueKindInvalidRepoSpec) {
+		t.Fatalf("expected invalid repo spec issue")
+	}
+}
+
+func TestValidateTemplatesInvalidYAML(t *testing.T) {
+	rootDir := t.TempDir()
+	data := []byte("templates: [")
+	path := filepath.Join(rootDir, FileName)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write templates: %v", err)
+	}
+	result, err := Validate(rootDir)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !hasIssueKind(result.Issues, IssueKindInvalidYAML) {
+		t.Fatalf("expected invalid yaml issue")
+	}
+}
+
+func TestValidateTemplatesInvalidName(t *testing.T) {
+	rootDir := t.TempDir()
+	data := []byte(`templates:
+  bad name:
+    repos:
+      - git@github.com:org/app.git
+`)
+	path := filepath.Join(rootDir, FileName)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write templates: %v", err)
+	}
+	result, err := Validate(rootDir)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !hasIssueKind(result.Issues, IssueKindInvalidTemplateName) {
+		t.Fatalf("expected invalid template name issue")
+	}
+}
+
+func hasIssueKind(issues []ValidationIssue, kind string) bool {
+	for _, issue := range issues {
+		if issue.Kind == kind {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add `gws template validate` to check templates.yaml structure and repo specs
- render validation issues with standard Result output and fail when invalid
- enforce 2-space YAML indentation on template save
- update docs and specs

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...

Fixes #61