### PR TITLE
Add debug file logging with UI phase context

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -57,9 +57,10 @@ Steps
 ```
 
 ## Command execution logs
-- Logs are included in Steps (not only verbose).
+- Steps may include user-facing command logs.
 - Use muted color (low contrast, non-flashy).
 - Command output lines can be visually connected using tree glyphs.
+- Debug logging is written to files when `--debug` is provided (no on-screen Debug section).
 
 Example:
 ```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -14,8 +14,31 @@ This directory holds command-level specifications in English. Each file uses fro
 ## Global CLI behavior
 - Command form: `gws <command> [flags] [args]`.
 - Root resolution precedence: `--root` flag > `GWS_ROOT` environment variable > default `~/gws`.
-- Common flags: `--root <path>`, `--no-prompt`, `--verbose`/`-v`, `--help`/`-h`.
+- Common flags: `--root <path>`, `--no-prompt`, `--debug`, `--help`/`-h`.
 - Output: human-readable text only in the current MVP; JSON output is future work.
+
+## Debug logging
+- `--debug` enables debug logging to a file (no on-screen debug output).
+- Output directory: `<GWS_ROOT>/logs/`.
+- File naming: `debug-YYYYMMDD.log` using local date.
+- Append mode: always append to the day file (single file per day).
+- Format: one event per line, human-readable key/value pairs.
+- Required fields: `ts`, `pid`, `trace`, `kind`, `phase`.
+- Optional fields: `ws` (workspace id when known), `cmd`, `line`, `code`, `prompt`, `step`, `step_id`.
+- `trace` is generated per command execution.
+- `kind` values: `cmd`, `stdout`, `stderr`, `exit`.
+- `phase` values: `inputs`, `info`, `steps`, `result`, `prompt`, `none`.
+- `prompt` is used only when `phase=prompt` (e.g. `prompt=workspace-id`).
+- `step`/`step_id` are used only when `phase=steps` (both are set).
+
+Example:
+```
+ts=2026-01-17T12:34:56.789-08:00 pid=12345 trace=git:abcd phase=steps step=2 step_id=repo-get kind=cmd cmd="git fetch origin main"
+ts=2026-01-17T12:34:56.912-08:00 pid=12345 trace=git:abcd phase=steps step=2 step_id=repo-get kind=stdout line="..."
+ts=2026-01-17T12:34:57.003-08:00 pid=12345 trace=git:abcd phase=steps step=2 step_id=repo-get kind=stderr line="..."
+ts=2026-01-17T12:34:57.010-08:00 pid=12345 trace=git:abcd phase=steps step=2 step_id=repo-get kind=exit code=0
+ts=2026-01-17T12:35:01.000-08:00 pid=12345 trace=exec:beef phase=prompt prompt=workspace-id kind=cmd cmd="gh api -X GET ..."
+```
 
 ## Spec files
 Current command specs live in this folder:

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -35,7 +35,7 @@ func printGlobalHelp(w io.Writer) {
 	fmt.Fprintln(w, "Global flags:")
 	fmt.Fprintln(w, "  --root <path>      override GWS_ROOT")
 	fmt.Fprintln(w, "  --no-prompt        disable interactive prompt")
-	fmt.Fprintln(w, "  --verbose, -v      verbose logs")
+	fmt.Fprintln(w, "  --debug            write debug logs to file")
 	fmt.Fprintln(w, "  --help, -h         show help")
 }
 

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-isatty"
+	"github.com/tasuku43/gws/internal/core/debuglog"
 	"github.com/tasuku43/gws/internal/core/output"
 	"github.com/tasuku43/gws/internal/domain/workspace"
 	"github.com/tasuku43/gws/internal/ui"
@@ -128,8 +129,17 @@ func runWorkspaceOpen(ctx context.Context, rootDir string, args []string, noProm
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), fmt.Sprintf("GWS_WORKSPACE=%s", workspaceID))
 	cmd.Env = append(cmd.Env, extraEnv...)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("open shell: %w", err)
+	trace := ""
+	if debuglog.Enabled() {
+		trace = debuglog.NewTrace("exec")
+		debuglog.LogCommand(trace, debuglog.FormatCommand(cmdPath, launchArgs))
+	}
+	runErr := cmd.Run()
+	if debuglog.Enabled() {
+		debuglog.LogExit(trace, debuglog.ExitCode(runErr))
+	}
+	if runErr != nil {
+		return fmt.Errorf("open shell: %w", runErr)
 	}
 	return nil
 }

--- a/internal/core/debuglog/debuglog.go
+++ b/internal/core/debuglog/debuglog.go
@@ -1,0 +1,217 @@
+package debuglog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type loggerState struct {
+	mu      sync.Mutex
+	enabled atomic.Bool
+	writer  *os.File
+	pid     int
+}
+
+var state loggerState
+var traceSeq uint64
+var ctxState debugContext
+
+type debugContext struct {
+	mu     sync.Mutex
+	phase  string
+	prompt string
+	step   string
+	stepID string
+}
+
+func Enable(rootDir string) error {
+	if strings.TrimSpace(rootDir) == "" {
+		return fmt.Errorf("root directory is required")
+	}
+	logDir := filepath.Join(rootDir, "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return fmt.Errorf("create debug log dir: %w", err)
+	}
+	name := fmt.Sprintf("debug-%s.log", time.Now().Format("20060102"))
+	path := filepath.Join(logDir, name)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open debug log file: %w", err)
+	}
+	state.mu.Lock()
+	if state.writer != nil {
+		_ = state.writer.Close()
+	}
+	state.writer = file
+	state.pid = os.Getpid()
+	state.enabled.Store(true)
+	state.mu.Unlock()
+	return nil
+}
+
+func Close() error {
+	state.mu.Lock()
+	state.enabled.Store(false)
+	var err error
+	if state.writer != nil {
+		err = state.writer.Close()
+		state.writer = nil
+	}
+	state.mu.Unlock()
+	return err
+}
+
+func Enabled() bool {
+	return state.enabled.Load()
+}
+
+func NewTrace(prefix string) string {
+	value := atomic.AddUint64(&traceSeq, 1)
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		prefix = "cmd"
+	}
+	return fmt.Sprintf("%s:%x", prefix, value)
+}
+
+func FormatCommand(name string, args []string) string {
+	if len(args) == 0 {
+		return strings.TrimSpace(name)
+	}
+	return strings.TrimSpace(name + " " + strings.Join(args, " "))
+}
+
+func LogCommand(trace, cmd string) {
+	logLine(trace, "cmd", cmd, "", nil)
+}
+
+func LogStdoutLines(trace, text string) {
+	logOutputLines(trace, "stdout", text)
+}
+
+func LogStderrLines(trace, text string) {
+	logOutputLines(trace, "stderr", text)
+}
+
+func LogExit(trace string, code int) {
+	logLine(trace, "exit", "", "", &code)
+}
+
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	type exitCoder interface {
+		ExitCode() int
+	}
+	if ec, ok := err.(exitCoder); ok {
+		return ec.ExitCode()
+	}
+	return -1
+}
+
+func SetPrompt(label string) {
+	ctxState.mu.Lock()
+	ctxState.phase = "prompt"
+	ctxState.prompt = strings.TrimSpace(label)
+	ctxState.step = ""
+	ctxState.stepID = ""
+	ctxState.mu.Unlock()
+}
+
+func ClearPrompt() {
+	ctxState.mu.Lock()
+	if ctxState.phase == "prompt" {
+		ctxState.phase = ""
+	}
+	ctxState.prompt = ""
+	ctxState.mu.Unlock()
+}
+
+func SetStep(index int, stepID string) {
+	ctxState.mu.Lock()
+	ctxState.phase = "steps"
+	ctxState.prompt = ""
+	ctxState.step = fmt.Sprintf("%d", index)
+	ctxState.stepID = strings.TrimSpace(stepID)
+	ctxState.mu.Unlock()
+}
+
+func SetPhase(phase string) {
+	ctxState.mu.Lock()
+	ctxState.phase = strings.TrimSpace(phase)
+	ctxState.prompt = ""
+	ctxState.step = ""
+	ctxState.stepID = ""
+	ctxState.mu.Unlock()
+}
+
+func logOutputLines(trace, kind, text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		logLine(trace, kind, "", line, nil)
+	}
+}
+
+func logLine(trace, kind, cmd, line string, code *int) {
+	if !Enabled() {
+		return
+	}
+	trace = strings.TrimSpace(trace)
+	if trace == "" {
+		trace = "unknown"
+	}
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		kind = "info"
+	}
+	phase, prompt, step, stepID := snapshotContext()
+	if phase == "" {
+		phase = "none"
+	}
+	ts := time.Now().Format(time.RFC3339Nano)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.writer == nil {
+		return
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "ts=%s pid=%d trace=%s phase=%s kind=%s", ts, state.pid, trace, phase, kind)
+	if prompt != "" {
+		fmt.Fprintf(&b, " prompt=%q", prompt)
+	}
+	if step != "" {
+		fmt.Fprintf(&b, " step=%s", step)
+	}
+	if stepID != "" {
+		fmt.Fprintf(&b, " step_id=%s", stepID)
+	}
+	if cmd != "" {
+		fmt.Fprintf(&b, " cmd=%q", cmd)
+	}
+	if line != "" {
+		fmt.Fprintf(&b, " line=%q", line)
+	}
+	if code != nil {
+		fmt.Fprintf(&b, " code=%d", *code)
+	}
+	b.WriteByte('\n')
+	_, _ = state.writer.Write([]byte(b.String()))
+}
+
+func snapshotContext() (string, string, string, string) {
+	ctxState.mu.Lock()
+	defer ctxState.mu.Unlock()
+	return ctxState.phase, ctxState.prompt, ctxState.step, ctxState.stepID
+}

--- a/internal/core/gitcmd/verbose.go
+++ b/internal/core/gitcmd/verbose.go
@@ -1,29 +1,7 @@
 package gitcmd
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/tasuku43/gws/internal/core/output"
-)
-
-var verbose bool
-
-func SetVerbose(v bool) {
-	verbose = v
-}
-
-func IsVerbose() bool {
-	return verbose
-}
+import "github.com/tasuku43/gws/internal/core/output"
 
 func Logf(format string, args ...any) {
-	if verbose {
-		return
-	}
-	if output.HasStepLogger() {
-		output.Logf("$ "+format, args...)
-		return
-	}
-	fmt.Fprintf(os.Stderr, "%s$ "+format+"\n", append([]any{output.Indent}, args...)...)
+	output.Logf("$ "+format, args...)
 }

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/tasuku43/gws/internal/core/debuglog"
 	"github.com/tasuku43/gws/internal/core/output"
 )
 
@@ -53,6 +54,8 @@ type BlockedChoice struct {
 }
 
 func PromptNewWorkspaceInputs(title string, templates []string, templateName string, workspaceID string, theme Theme, useColor bool) (string, string, error) {
+	debuglog.SetPrompt("workspace-inputs")
+	defer debuglog.ClearPrompt()
 	model := newInputsModel(title, templates, templateName, workspaceID, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -66,6 +69,8 @@ func PromptNewWorkspaceInputs(title string, templates []string, templateName str
 }
 
 func PromptWorkspaceAndRepo(title string, workspaces []WorkspaceChoice, repos []PromptChoice, workspaceID, repoSpec string, theme Theme, useColor bool) (string, string, error) {
+	debuglog.SetPrompt("workspace-and-repo")
+	defer debuglog.ClearPrompt()
 	model := newAddInputsModel(title, workspaces, repos, workspaceID, repoSpec, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -79,6 +84,8 @@ func PromptWorkspaceAndRepo(title string, workspaces []WorkspaceChoice, repos []
 }
 
 func PromptWorkspace(title string, workspaces []WorkspaceChoice, theme Theme, useColor bool) (string, error) {
+	debuglog.SetPrompt("workspace")
+	defer debuglog.ClearPrompt()
 	model := newWorkspaceSelectModel(title, workspaces, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -92,6 +99,8 @@ func PromptWorkspace(title string, workspaces []WorkspaceChoice, theme Theme, us
 }
 
 func PromptWorkspaceWithBlocked(title string, workspaces []WorkspaceChoice, blocked []BlockedChoice, theme Theme, useColor bool) (string, error) {
+	debuglog.SetPrompt("workspace")
+	defer debuglog.ClearPrompt()
 	model := newWorkspaceSelectModelWithBlocked(title, workspaces, blocked, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -105,6 +114,8 @@ func PromptWorkspaceWithBlocked(title string, workspaces []WorkspaceChoice, bloc
 }
 
 func PromptWorkspaceMultiSelectWithBlocked(title string, workspaces []WorkspaceChoice, blocked []BlockedChoice, theme Theme, useColor bool) ([]string, error) {
+	debuglog.SetPrompt("workspace")
+	defer debuglog.ClearPrompt()
 	model := newWorkspaceMultiSelectModel(title, workspaces, blocked, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -121,6 +132,8 @@ func PromptWorkspaceMultiSelectWithBlocked(title string, workspaces []WorkspaceC
 }
 
 func PromptConfirmInline(label string, theme Theme, useColor bool) (bool, error) {
+	debuglog.SetPrompt(label)
+	defer debuglog.ClearPrompt()
 	model := newConfirmInlineModel(label, theme, useColor, false, nil, nil)
 	out, err := runProgram(model)
 	if err != nil {
@@ -134,6 +147,8 @@ func PromptConfirmInline(label string, theme Theme, useColor bool) (bool, error)
 }
 
 func PromptConfirmInlineInfo(label string, theme Theme, useColor bool) (bool, error) {
+	debuglog.SetPrompt(label)
+	defer debuglog.ClearPrompt()
 	model := newConfirmInlineModel(label, theme, useColor, true, nil, nil)
 	out, err := runProgram(model)
 	if err != nil {
@@ -1047,6 +1062,8 @@ func (m confirmInlineModel) View() string {
 // PromptInputInline collects a single inline value with an optional default and validation.
 // Empty input accepts the default. Validation errors are shown inline and reprompted.
 func PromptInputInline(label, defaultValue string, validate func(string) error, theme Theme, useColor bool) (string, error) {
+	debuglog.SetPrompt(label)
+	defer debuglog.ClearPrompt()
 	model := newInputInlineModel(label, defaultValue, validate, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -1151,6 +1168,8 @@ func (m inputInlineModel) View() string {
 // PromptTemplateRepos lets users pick one or more repos from a list with filtering.
 // It can also collect a template name when not provided.
 func PromptTemplateRepos(title string, templateName string, choices []PromptChoice, theme Theme, useColor bool) (string, []string, error) {
+	debuglog.SetPrompt("template-repos")
+	defer debuglog.ClearPrompt()
 	model := newTemplateRepoSelectModel(title, templateName, choices, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -1165,6 +1184,8 @@ func PromptTemplateRepos(title string, templateName string, choices []PromptChoi
 
 // PromptTemplateName asks for a template name via text input.
 func PromptTemplateName(title string, defaultValue string, theme Theme, useColor bool) (string, error) {
+	debuglog.SetPrompt("template-name")
+	defer debuglog.ClearPrompt()
 	model := newTemplateNameModel(title, defaultValue, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -1179,6 +1200,8 @@ func PromptTemplateName(title string, defaultValue string, theme Theme, useColor
 
 // PromptChoiceSelect lets users pick a single choice from a list with filtering.
 func PromptChoiceSelect(title, label string, choices []PromptChoice, theme Theme, useColor bool) (string, error) {
+	debuglog.SetPrompt(label)
+	defer debuglog.ClearPrompt()
 	model := newChoiceSelectModel(title, label, choices, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -1194,6 +1217,8 @@ func PromptChoiceSelect(title, label string, choices []PromptChoice, theme Theme
 // PromptChoiceSelectWithOutput lets users pick a single choice from a list with filtering.
 // It renders the prompt to the provided writer.
 func PromptChoiceSelectWithOutput(title, label string, choices []PromptChoice, theme Theme, useColor bool, out io.Writer) (string, error) {
+	debuglog.SetPrompt(label)
+	defer debuglog.ClearPrompt()
 	model := newChoiceSelectModel(title, label, choices, theme, useColor)
 	finalModel, err := runProgramWithOutput(model, out)
 	if err != nil {
@@ -1208,6 +1233,8 @@ func PromptChoiceSelectWithOutput(title, label string, choices []PromptChoice, t
 
 // PromptMultiSelect lets users pick one or more choices from a list with filtering.
 func PromptMultiSelect(title, label string, choices []PromptChoice, theme Theme, useColor bool) ([]string, error) {
+	debuglog.SetPrompt(label)
+	defer debuglog.ClearPrompt()
 	model := newMultiSelectModel(title, label, choices, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -1221,6 +1248,8 @@ func PromptMultiSelect(title, label string, choices []PromptChoice, theme Theme,
 }
 
 func PromptIssueSelectWithBranches(title, label string, choices []PromptChoice, validateBranch func(string) error, theme Theme, useColor bool) ([]IssueSelection, error) {
+	debuglog.SetPrompt(label)
+	defer debuglog.ClearPrompt()
 	model := newIssueBranchSelectModel(title, label, choices, validateBranch, theme, useColor)
 	out, err := runProgram(model)
 	if err != nil {
@@ -1234,6 +1263,8 @@ func PromptIssueSelectWithBranches(title, label string, choices []PromptChoice, 
 }
 
 func PromptCreateFlow(title string, startMode string, defaultWorkspaceID string, templateName string, templates []string, templateErr error, repoChoices []PromptChoice, repoErr error, reviewRepos []PromptChoice, issueRepos []PromptChoice, loadReview func(string) ([]PromptChoice, error), loadIssue func(string) ([]PromptChoice, error), loadTemplateRepos func(string) ([]string, error), validateBranch func(string) error, theme Theme, useColor bool, selectedRepo string) (string, string, string, string, []string, string, []string, string, []IssueSelection, string, error) {
+	debuglog.SetPrompt("create-flow")
+	defer debuglog.ClearPrompt()
 	model := newCreateFlowModel(title, templates, templateErr, repoChoices, repoErr, defaultWorkspaceID, templateName, reviewRepos, issueRepos, loadReview, loadIssue, loadTemplateRepos, validateBranch, theme, useColor, startMode, selectedRepo)
 	if model.err != nil {
 		return "", "", "", "", nil, "", nil, "", nil, "", model.err

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/tasuku43/gws/internal/core/debuglog"
 	"github.com/tasuku43/gws/internal/core/output"
 )
 
@@ -32,6 +33,18 @@ func (r *Renderer) Blank() {
 }
 
 func (r *Renderer) Section(title string) {
+	switch strings.ToLower(strings.TrimSpace(title)) {
+	case "inputs":
+		debuglog.SetPhase("inputs")
+	case "info":
+		debuglog.SetPhase("info")
+	case "steps":
+		debuglog.SetPhase("steps")
+	case "result":
+		debuglog.SetPhase("result")
+	default:
+		debuglog.SetPhase("none")
+	}
 	r.writeLine(r.style(title, r.theme.SectionTitle))
 }
 


### PR DESCRIPTION
## Summary
- add file-based debug logging with per-line phase/prompt/step context
- track external command and git execution into daily log files
- wire prompt and UI sections to set debug phases

## Testing
- go test ./...
- go vet ./...
- go build ./...