### PR TITLE
Clarify GitHub-only create modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ so humans and multiple AI agents can work in parallel without stepping on each o
 
 - Git
 - Go 1.24+ (build/run from source)
-- gh CLI (required for `gws create --review` and `gws create --issue` picker)
+- gh CLI (required for `gws create --review` and `gws create --issue` — GitHub only)
 
 ## Quickstart (5 minutes)
 
@@ -83,6 +83,20 @@ gws create --review https://github.com/owner/repo/pull/123
 - Creates `OWNER-REPO-REVIEW-PR-123`
 - Fetches the PR head branch (forks not supported)
 - Requires `gh` authentication
+
+## Create from an Issue (GitHub only)
+
+```bash
+gws create --issue https://github.com/owner/repo/issues/123
+```
+
+- Creates `OWNER-REPO-ISSUE-123`
+- Defaults branch to `issue/123`
+- Requires `gh` authentication
+
+## Provider support (summary)
+- `gws create --repo` and `gws create --template` are provider-agnostic (any Git host URL).
+- `gws create --review` and `gws create --issue` are GitHub-only today.
 
 ## How gws lays out files
 

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -103,6 +103,16 @@ Result
     └─ helmfiles (branch: SREP-123)
 ```
 
+### gws create (mode picker)
+```
+Inputs
+  • mode: s
+    └─ repo - 1 repo only
+    └─ issue - From an issue (multi-select, GitHub only)
+    └─ review - From a review request (multi-select, GitHub only)
+    └─ template - From template
+```
+
 ### gws create --template (non-interactive)
 ```
 Steps

--- a/docs/specs/create.md
+++ b/docs/specs/create.md
@@ -13,6 +13,7 @@ Unify all workspace creation flows under a single command and keep "create" sema
 - Exactly one of `--template`, `--review`, `--issue`, or `--repo` can be specified. If multiple are provided, error.
 - If none are provided and prompts are allowed, enter an interactive mode picker.
   - The picker presents `template`, `repo`, `review`, `issue` and supports arrow selection with filterable search.
+  - `review` and `issue` are GitHub-only modes; `repo` and `template` are provider-agnostic.
 - If none are provided and `--no-prompt` is set, error.
 - When prompts are used, mode flags (`--template`, `--review`, `--issue`, `--repo`) still run the unified create prompt flow so the Inputs section is rendered as a single in-place interaction.
 
@@ -120,10 +121,11 @@ Same behavior as the former `gws issue`.
 
 ### Behavior
 - If `ISSUE_URL` is provided:
+  - Accepts GitHub issue URLs only (e.g., `https://github.com/owner/repo/issues/123`).
   - Parse the URL to obtain `owner`, `repo`, and `issue number`.
   - Workspace ID: defaults to `<OWNER>-<REPO>-ISSUE-<number>` (owner/repo uppercased); can be overridden with `--workspace-id`. Must pass `git check-ref-format --branch`. If the workspace already exists, error.
   - Branch: defaults to `issue/<number>`. Before proceeding, prompt the user with the default and allow editing unless `--no-prompt` or `--branch` is supplied.
-  - For GitHub issues, uses `gh api` to fetch the issue title and saves it as the workspace description.
+  - Uses `gh api` to fetch the issue title and saves it as the workspace description (requires authenticated GitHub CLI).
     - If the branch exists in the bare store, use it.
     - If the branch exists on `origin` but not locally, fetch it and create a tracking branch.
     - If not, create it from a base ref.
@@ -136,7 +138,7 @@ Same behavior as the former `gws issue`.
 - If `ISSUE_URL` is omitted and prompts are allowed (interactive picker):
   - `--no-prompt` with no URL => error.
   - Step 1: pick a repo from fetched bare stores whose origin remote resolves to a supported host. Display `alias (host/owner/repo)`; filterable by substring.
-  - Step 2: fetch open issues for the chosen repo from the host API (GitHub via `gh api`; other hosts may be added later). Default fetch: latest 50 open issues sorted by updated desc.
+  - Step 2: fetch open issues for the chosen repo via `gh api` (GitHub only). Default fetch: latest 50 open issues sorted by updated desc.
 - Step 3: multi-select issues using the same add/remove loop as `gws template add` (filterable list; `<Enter>` adds; `<Ctrl+D>` or `done` to finish; minimum 1 selection).
   - For each selected issue:
     - Workspace ID = `<OWNER>-<REPO>-ISSUE-<number>` (owner/repo uppercased, no per-item override in this flow).
@@ -152,7 +154,7 @@ Same behavior as the former `gws issue`.
 - For picker mode: each selected issue produces a workspace with the same guarantees; partial success is reported if a later item fails.
 
 ### Failure Modes
-- Unsupported or invalid issue URL.
+- Unsupported or invalid issue URL; non-GitHub host.
 - Workspace already exists.
 - Repo store missing and user declines/forbids `repo get`.
 - Git errors when creating/fetching branch or adding the worktree.

--- a/internal/cli/provider.go
+++ b/internal/cli/provider.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type provider interface {
+	Name() string
+	FetchIssues(ctx context.Context, host, owner, repoName string) ([]issueSummary, error)
+	FetchIssue(ctx context.Context, host, owner, repoName string, number int) (issueSummary, error)
+	FetchPRs(ctx context.Context, host, owner, repoName string) ([]prSummary, error)
+	FetchPR(ctx context.Context, host, owner, repoName string, number int) (prSummary, error)
+}
+
+type githubProvider struct{}
+
+func (githubProvider) Name() string {
+	return "github"
+}
+
+func (githubProvider) FetchIssues(ctx context.Context, host, owner, repoName string) ([]issueSummary, error) {
+	return fetchGitHubIssues(ctx, host, owner, repoName)
+}
+
+func (githubProvider) FetchIssue(ctx context.Context, host, owner, repoName string, number int) (issueSummary, error) {
+	return fetchGitHubIssue(ctx, host, owner, repoName, number)
+}
+
+func (githubProvider) FetchPRs(ctx context.Context, host, owner, repoName string) ([]prSummary, error) {
+	return fetchGitHubPRs(ctx, host, owner, repoName)
+}
+
+func (githubProvider) FetchPR(ctx context.Context, host, owner, repoName string, number int) (prSummary, error) {
+	return fetchGitHubPR(ctx, host, owner, repoName, number)
+}
+
+var providers = map[string]provider{
+	"github": githubProvider{},
+}
+
+func providerByName(name string) (provider, error) {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		return nil, fmt.Errorf("provider is required")
+	}
+	p, ok := providers[key]
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider: %s", key)
+	}
+	return p, nil
+}
+
+func providerNameForHost(host string) string {
+	lower := strings.ToLower(strings.TrimSpace(host))
+	if strings.Contains(lower, "gitlab") {
+		return "gitlab"
+	}
+	if strings.Contains(lower, "bitbucket") {
+		return "bitbucket"
+	}
+	return "github"
+}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -739,8 +739,8 @@ func (m createFlowModel) filterModes() []PromptChoice {
 	q := strings.ToLower(strings.TrimSpace(m.modeInput.Value()))
 	choices := []PromptChoice{
 		{Label: "repo", Value: "repo", Description: "1 repo only"},
-		{Label: "issue", Value: "issue", Description: "From an issue (multi-select)"},
-		{Label: "review", Value: "review", Description: "From a review request (multi-select)"},
+		{Label: "issue", Value: "issue", Description: "From an issue (multi-select, GitHub only)"},
+		{Label: "review", Value: "review", Description: "From a review request (multi-select, GitHub only)"},
 		{Label: "template", Value: "template", Description: "From template"},
 	}
 	if q == "" {


### PR DESCRIPTION
## Summary
- clarify GitHub-only limitations for create review/issue in CLI mode picker
- document provider scope in README/spec/UI examples
- keep provider scaffolding for future expansion

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...