### PR TITLE
ui: wrap long lines in prompts and lists

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -38,6 +38,7 @@ Rules:
 - Section order is fixed: Inputs → Info → Steps → Result → Suggestion
 - Result lines are bullets (use the same prefix as Steps)
 - No success banner; success is implied in Result section
+- Long lines should wrap to the terminal width; continuation lines keep the same text indent (prefix width)
 
 ## Prefix & Indentation
 - Default prefix token: `•` (can be changed later)

--- a/internal/ui/wrap.go
+++ b/internal/ui/wrap.go
@@ -1,0 +1,16 @@
+package ui
+
+import "sync/atomic"
+
+var wrapWidth atomic.Int64
+
+func setWrapWidth(width int) {
+	if width <= 0 {
+		return
+	}
+	wrapWidth.Store(int64(width))
+}
+
+func currentWrapWidth() int {
+	return int(wrapWidth.Load())
+}


### PR DESCRIPTION
## Summary
- wrap long prompt/output lines to terminal width
- apply wrapping to raw selection list lines with prefix-aware indentation
- document line-wrapping behavior in UI spec

## Testing
- gofmt -w .
- go test ./...
- go vet ./...
- go build ./...