### PR TITLE
Handle workspace remove when cwd is inside target

### DIFF
--- a/docs/spec/commands/apply.md
+++ b/docs/spec/commands/apply.md
@@ -23,6 +23,7 @@ Reconcile the filesystem to match `gion.yaml` by computing a diff, showing a pla
   - For destructive actions, the prompt does not repeat per-repo git status output; users should review the plan output above before confirming.
 - If confirmed, applies actions in a stable order: removes, then updates, then adds.
   - When a repo update is a branch rename only (same repo key, different branch), gion renames the branch in-place (no worktree remove/add) to match common local development workflows.
+- During destructive workspace removal, if the current process cwd is inside `workspaces/<id>/...`, gion must first shift process cwd to `<root>` before any worktree removal starts.
 - When applying `add` actions that require creating a new branch:
   - If the target `branch` already exists in the bare store, gion checks it out when adding the worktree.
   - If the branch does not exist, gion creates it from:

--- a/internal/domain/workspace/remove.go
+++ b/internal/domain/workspace/remove.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/tasuku43/gion/internal/infra/gitcmd"
 	"github.com/tasuku43/gion/internal/infra/paths"
@@ -34,6 +36,9 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 		return err
 	} else if !exists {
 		return fmt.Errorf("workspace does not exist: %s", wsDir)
+	}
+	if err := shiftCWDToRootIfInsideWorkspace(rootDir, wsDir); err != nil {
+		return err
 	}
 
 	repos, warnings, err := ScanRepos(ctx, wsDir)
@@ -84,4 +89,44 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 	}
 
 	return nil
+}
+
+func shiftCWDToRootIfInsideWorkspace(rootDir, workspaceDir string) error {
+	if strings.TrimSpace(rootDir) == "" || strings.TrimSpace(workspaceDir) == "" {
+		return nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working dir: %w", err)
+	}
+	if !pathInside(workspaceDir, cwd) {
+		return nil
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		return fmt.Errorf("shift process cwd to root: %w", err)
+	}
+	return nil
+}
+
+func pathInside(base, target string) bool {
+	if strings.TrimSpace(base) == "" || strings.TrimSpace(target) == "" {
+		return false
+	}
+	basePath := filepath.Clean(base)
+	targetPath := filepath.Clean(target)
+	if resolved, err := filepath.EvalSymlinks(basePath); err == nil {
+		basePath = filepath.Clean(resolved)
+	}
+	if resolved, err := filepath.EvalSymlinks(targetPath); err == nil {
+		targetPath = filepath.Clean(resolved)
+	}
+	rel, err := filepath.Rel(basePath, targetPath)
+	if err != nil {
+		return false
+	}
+	rel = filepath.Clean(rel)
+	if rel == "." {
+		return true
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/domain/workspace/repo_workspace_test.go
+++ b/internal/domain/workspace/repo_workspace_test.go
@@ -81,6 +81,89 @@ func TestRepoGetWorkspaceAddRemove(t *testing.T) {
 	}
 }
 
+func TestWorkspaceRemoveShiftsProcessCWDWhenInsideTargetWorkspace(t *testing.T) {
+	t.Setenv("GIT_AUTHOR_NAME", "gion")
+	t.Setenv("GIT_AUTHOR_EMAIL", "gion@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "gion")
+	t.Setenv("GIT_COMMITTER_EMAIL", "gion@example.com")
+
+	ctx := context.Background()
+	tmp := t.TempDir()
+	rootDir := filepath.Join(tmp, "gion")
+
+	remoteBase := filepath.Join(tmp, "remotes")
+	remotePath := filepath.Join(remoteBase, "org", "repo.git")
+	if err := os.MkdirAll(filepath.Dir(remotePath), 0o755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	runGit(t, "", "init", "--bare", remotePath)
+
+	seedDir := filepath.Join(tmp, "seed")
+	runGit(t, "", "init", seedDir)
+	runGit(t, seedDir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seedDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "init")
+	runGit(t, seedDir, "remote", "add", "origin", remotePath)
+	runGit(t, seedDir, "push", "origin", "main")
+	runGit(t, "", "--git-dir", remotePath, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	configPath := filepath.Join(tmp, "gitconfig")
+	fileURL := "file://" + filepath.ToSlash(remoteBase) + "/"
+	configData := fmt.Sprintf("[url \"%s\"]\n\tinsteadOf = https://example.com/\n", fileURL)
+	if err := os.WriteFile(configPath, []byte(configData), 0o644); err != nil {
+		t.Fatalf("write gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
+
+	repoSpec := "https://example.com/org/repo.git"
+	if _, err := repo.Get(ctx, rootDir, repoSpec); err != nil {
+		t.Fatalf("repo get: %v", err)
+	}
+	if _, err := workspace.New(ctx, rootDir, "WS-1"); err != nil {
+		t.Fatalf("workspace new: %v", err)
+	}
+	if _, err := workspace.Add(ctx, rootDir, "WS-1", repoSpec, "", true); err != nil {
+		t.Fatalf("workspace add: %v", err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	worktreePath := workspace.WorktreePath(rootDir, "WS-1", "repo")
+	if err := os.Chdir(worktreePath); err != nil {
+		t.Fatalf("Chdir(%s) error: %v", worktreePath, err)
+	}
+
+	if err := workspace.Remove(ctx, rootDir, "WS-1"); err != nil {
+		t.Fatalf("workspace remove: %v", err)
+	}
+
+	afterWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() after remove error: %v", err)
+	}
+	afterResolved := afterWD
+	if resolved, err := filepath.EvalSymlinks(afterWD); err == nil {
+		afterResolved = resolved
+	}
+	rootResolved := rootDir
+	if resolved, err := filepath.EvalSymlinks(rootDir); err == nil {
+		rootResolved = resolved
+	}
+	if afterResolved != rootResolved {
+		t.Fatalf("process cwd = %q (resolved=%q), want %q (resolved=%q)", afterWD, afterResolved, rootDir, rootResolved)
+	}
+}
+
 func TestWorkspaceAddSkipsFetchWhenUpToDate(t *testing.T) {
 	t.Setenv("GIT_AUTHOR_NAME", "gion")
 	t.Setenv("GIT_AUTHOR_EMAIL", "gion@example.com")


### PR DESCRIPTION
## Summary
- shift the process cwd to `GION_ROOT` before destructive workspace removal when the current cwd is inside the target workspace
- document the cwd-safety rule in the `gion apply` spec
- add a regression test covering removal from inside the target workspace

## Testing
- go test ./...
- go vet ./...
- go build ./...