### PR TITLE
Sync shell cwd after workspace removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,6 @@ Resulting worktree:
 ```bash
 # Setup (once; shell integration + completion):
 eval "$(gion shell init zsh --with-completion)"
-
-# Optional: if you use giongo for fast navigation
-# eval "$(giongo init)"
 giongo
 ```
 
@@ -246,6 +243,7 @@ eval "$(gion shell init zsh --with-completion)"
 This enables:
 - parent-shell `cd` after successful destructive workspace removal
 - shell completion in the same setup step
+- `giongo` navigation without a separate `giongo init` step
 
 Example (zsh function):
 
@@ -261,15 +259,9 @@ giongo() {
 }
 ```
 
-Optional shortcut (auto-generate the function for your shell if you use `giongo`):
-
-```bash
-eval "$(giongo init)"
-```
-
 Notes:
 - `gion shell init` is the primary shell integration path for `gion` commands.
-- `giongo init` is only for the `giongo` jump helper.
+- `gion shell init` also installs the `giongo` shell wrapper.
 - For a permanent setup, paste the output into `~/.zshrc` or `~/.bashrc`.
 
 ### Cleanup

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Resulting worktree:
 # Setup (once; shell integration + completion):
 eval "$(gion shell init zsh --with-completion)"
 
-# Optional: keep giongo shortcut too
-eval "$(giongo init)"
+# Optional: if you use giongo for fast navigation
+# eval "$(giongo init)"
 giongo
 ```
 
@@ -261,15 +261,15 @@ giongo() {
 }
 ```
 
-Shortcut (auto-generate the function for your shell):
+Optional shortcut (auto-generate the function for your shell if you use `giongo`):
 
 ```bash
 eval "$(giongo init)"
 ```
 
 Notes:
-- `giongo init` outputs a bash/zsh function definition.
 - `gion shell init` is the primary shell integration path for `gion` commands.
+- `giongo init` is only for the `giongo` jump helper.
 - For a permanent setup, paste the output into `~/.zshrc` or `~/.bashrc`.
 
 ### Cleanup

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ brew install gion
 - Version pinning with mise (optional): `mise use -g github:tasuku43/gion@<version>`
 - Manual install via GitHub Releases (download archive → put `gion` and `giongo` on your PATH)
 - Build from source requires Go 1.24+
+- Shell integration (recommended for safe workspace removal and faster setup):
+  - `eval "$(gion shell init zsh --with-completion)"`
+  - `eval "$(gion shell init bash --with-completion)"`
 
 ### Requirements
 
@@ -134,7 +137,10 @@ Resulting worktree:
 ### 4) Jump into a workspace (interactive)
 
 ```bash
-# Setup (once):
+# Setup (once; shell integration + completion):
+eval "$(gion shell init zsh --with-completion)"
+
+# Optional: keep giongo shortcut too
 eval "$(giongo init)"
 giongo
 ```
@@ -231,6 +237,16 @@ gion manifest add --preset app PROJ-123
 `giongo` is a small companion binary that jumps into a workspace or repo using a picker.  
 It does not change any state.
 
+For `gion` itself, prefer `gion shell init` as the primary shell integration entrypoint:
+
+```bash
+eval "$(gion shell init zsh --with-completion)"
+```
+
+This enables:
+- parent-shell `cd` after successful destructive workspace removal
+- shell completion in the same setup step
+
 Example (zsh function):
 
 ```bash
@@ -253,6 +269,7 @@ eval "$(giongo init)"
 
 Notes:
 - `giongo init` outputs a bash/zsh function definition.
+- `gion shell init` is the primary shell integration path for `gion` commands.
 - For a permanent setup, paste the output into `~/.zshrc` or `~/.bashrc`.
 
 ### Cleanup

--- a/docs/guides/COMMANDS.md
+++ b/docs/guides/COMMANDS.md
@@ -72,7 +72,7 @@ Common flags:
 `giongo` is a companion binary for fast navigation. It does not change any state.
 
 - `giongo --print` - select a destination and print its path.
-- `giongo init` - print a shell function for `cd "$(giongo --print ...)"` integration.
+- `giongo init` - legacy helper that prints a shell function for `giongo` integration.
 
 ## Further reading
 

--- a/docs/guides/COMMANDS.md
+++ b/docs/guides/COMMANDS.md
@@ -36,6 +36,8 @@ gion manifest rm PROJ-123
 - `gion plan` - show the diff between `gion.yaml` and the filesystem (no changes).
 - `gion apply` - reconcile the filesystem to match `gion.yaml` (prompts before destructive changes).
 - `gion import` - rebuild `gion.yaml` from the filesystem (when the filesystem is the source of truth).
+- `gion shell init [shell] [--with-completion]` - print shell integration code for parent-shell side effects.
+- `gion shell completion [shell]` - print shell completion script.
 - `gion doctor [--fix | --self]` - check workspace/repo health.
 - `gion version` - print version.
 - `gion help [command]` - show help (examples: `gion help manifest`, `gion help repo`).

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -48,3 +48,4 @@ Verify:
 
 Shell integration (optional):
 - `eval "$(giongo init)"`
+- `eval "$(gion completion zsh)"` or `eval "$(gion completion bash)"`

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -48,4 +48,5 @@ Verify:
 
 Shell integration (optional):
 - `eval "$(giongo init)"`
-- `eval "$(gion completion zsh)"` or `eval "$(gion completion bash)"`
+- `eval "$(gion shell init zsh)"`
+- `eval "$(gion shell init bash)"`

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -49,6 +49,3 @@ Verify:
 Shell integration (optional):
 - `eval "$(gion shell init zsh --with-completion)"`
 - `eval "$(gion shell init bash --with-completion)"`
-
-Optional `giongo` helper setup:
-- `eval "$(giongo init)"`

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -47,6 +47,8 @@ Verify:
 - `giongo --version`
 
 Shell integration (optional):
+- `eval "$(gion shell init zsh --with-completion)"`
+- `eval "$(gion shell init bash --with-completion)"`
+
+Optional `giongo` helper setup:
 - `eval "$(giongo init)"`
-- `eval "$(gion shell init zsh)"`
-- `eval "$(gion shell init bash)"`

--- a/docs/spec/commands/apply.md
+++ b/docs/spec/commands/apply.md
@@ -24,7 +24,7 @@ Reconcile the filesystem to match `gion.yaml` by computing a diff, showing a pla
 - If confirmed, applies actions in a stable order: removes, then updates, then adds.
   - When a repo update is a branch rename only (same repo key, different branch), gion renames the branch in-place (no worktree remove/add) to match common local development workflows.
 - During destructive workspace removal, if the current process cwd is inside `workspaces/<id>/...`, gion must first shift process cwd to `<root>` before any worktree removal starts.
-  - When shell integration from `gion completion bash|zsh` is active, successful workspace removal must emit a shell action that changes the parent shell cwd to `<root>`.
+  - When shell integration from `gion shell init` is active, successful workspace removal must emit a shell action that changes the parent shell cwd to `<root>`.
   - On failure, gion must not emit a shell action.
 - When applying `add` actions that require creating a new branch:
   - If the target `branch` already exists in the bare store, gion checks it out when adding the worktree.

--- a/docs/spec/commands/apply.md
+++ b/docs/spec/commands/apply.md
@@ -24,6 +24,8 @@ Reconcile the filesystem to match `gion.yaml` by computing a diff, showing a pla
 - If confirmed, applies actions in a stable order: removes, then updates, then adds.
   - When a repo update is a branch rename only (same repo key, different branch), gion renames the branch in-place (no worktree remove/add) to match common local development workflows.
 - During destructive workspace removal, if the current process cwd is inside `workspaces/<id>/...`, gion must first shift process cwd to `<root>` before any worktree removal starts.
+  - When shell integration from `gion completion bash|zsh` is active, successful workspace removal must emit a shell action that changes the parent shell cwd to `<root>`.
+  - On failure, gion must not emit a shell action.
 - When applying `add` actions that require creating a new branch:
   - If the target `branch` already exists in the bare store, gion checks it out when adding the worktree.
   - If the branch does not exist, gion creates it from:

--- a/docs/spec/commands/completion.md
+++ b/docs/spec/commands/completion.md
@@ -8,6 +8,8 @@ status: implemented
 
 Generate shell completion script for bash or zsh.
 
+The emitted script also installs a lightweight shell wrapper around `gion` so successful commands can apply shell actions such as `cd` after destructive workspace removal.
+
 ## Usage
 
 ```
@@ -40,6 +42,18 @@ Add to `~/.zshrc`:
 ```zsh
 eval "$(gion completion zsh)"
 ```
+
+## Shell action behavior
+
+When the completion script wrapper is active:
+
+- `gion` runs through a shell function wrapper rather than calling the binary directly
+- the wrapper provides a temporary action-file path via `GION_SHELL_ACTION_FILE`
+- on success, if `gion` writes a shell action, the wrapper sources it in the parent shell
+
+Current use:
+
+- successful workspace removal can move the parent shell cwd back to `GION_ROOT` when the previous cwd was inside the removed workspace
 
 ## Completion Coverage
 

--- a/docs/spec/commands/completion.md
+++ b/docs/spec/commands/completion.md
@@ -8,8 +8,6 @@ status: implemented
 
 Generate shell completion script for bash or zsh.
 
-The emitted script also installs a lightweight shell wrapper around `gion` so successful commands can apply shell actions such as `cd` after destructive workspace removal.
-
 ## Usage
 
 ```
@@ -32,7 +30,7 @@ If no shell is specified, defaults to `bash`.
 Add to `~/.bashrc`:
 
 ```bash
-eval "$(gion completion bash)"
+source <(gion completion bash)
 ```
 
 ### zsh
@@ -40,20 +38,10 @@ eval "$(gion completion bash)"
 Add to `~/.zshrc`:
 
 ```zsh
-eval "$(gion completion zsh)"
+source <(gion completion zsh)
 ```
 
-## Shell action behavior
-
-When the completion script wrapper is active:
-
-- `gion` runs through a shell function wrapper rather than calling the binary directly
-- the wrapper provides a temporary action-file path via `GION_SHELL_ACTION_FILE`
-- on success, if `gion` writes a shell action, the wrapper sources it in the parent shell
-
-Current use:
-
-- successful workspace removal can move the parent shell cwd back to `GION_ROOT` when the previous cwd was inside the removed workspace
+Shell integration is handled separately by `gion shell init`.
 
 ## Completion Coverage
 

--- a/docs/spec/commands/shell/completion.md
+++ b/docs/spec/commands/shell/completion.md
@@ -1,0 +1,23 @@
+---
+title: "gion shell completion"
+status: implemented
+---
+
+## Synopsis
+`gion shell completion [shell]`
+
+## Intent
+Print shell completion script for `gion`.
+
+## Behavior
+- Supports `bash` and `zsh`.
+- If `shell` is omitted, infer it from `SHELL`; default to `zsh` when inference fails.
+- Prints completion script to stdout.
+- Does not include shell integration wrapper logic; use `gion shell init` for parent-shell side effects.
+
+## Examples
+- `source <(gion shell completion bash)`
+- `source <(gion shell completion zsh)`
+
+## Failure Modes
+- Unsupported shell.

--- a/docs/spec/commands/shell/init.md
+++ b/docs/spec/commands/shell/init.md
@@ -1,0 +1,29 @@
+---
+title: "gion shell init"
+status: implemented
+---
+
+## Synopsis
+`gion shell init [shell] [--with-completion[=true|false]]`
+
+## Intent
+Print shell integration code that allows `gion` to apply parent-shell side effects through an action-file protocol.
+
+## Behavior
+- Supports `bash` and `zsh`.
+- If `shell` is omitted, infer it from `SHELL`; default to `zsh` when inference fails.
+- Prints a shell wrapper function to stdout.
+- The wrapper:
+  - creates a temporary action file
+  - runs `command gion` with `GION_SHELL_ACTION_FILE` pointing at that file
+  - applies the action file only when the command succeeds
+- `--with-completion` appends the same shell-specific script as `gion shell completion <shell>`.
+- `--with-completion=<value>` accepts `true/false`, `1/0`, `yes/no`, `on/off`.
+
+## Examples
+- `eval "$(gion shell init zsh)"`
+- `eval "$(gion shell init zsh --with-completion)"`
+
+## Failure Modes
+- Unsupported shell.
+- Invalid `--with-completion` value.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -98,6 +98,8 @@ func Run() error {
 		return runApply(ctx, rootDir, args[1:], noPrompt)
 	case "completion":
 		return runCompletion(args[1:])
+	case "shell":
+		return runShell(args[1:])
 	default:
 		return fmt.Errorf("unknown command: %s", args[0])
 	}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 const SupportedShells = "bash, zsh"
@@ -25,34 +26,32 @@ func runCompletion(args []string) error {
 	}
 }
 
+func renderShellCompletionScript(shell string) (string, error) {
+	var buf stringWriter
+	switch shell {
+	case "bash":
+		printBashCompletion(&buf)
+	case "zsh":
+		printZshCompletion(&buf)
+	default:
+		return "", fmt.Errorf("unsupported shell: %s (supported: %s)", shell, SupportedShells)
+	}
+	return buf.String(), nil
+}
+
 func printBashCompletion(w io.Writer) {
 	fmt.Fprintln(w, `# gion bash completion
-__gion_run() {
-  local action_file
-  action_file="$(mktemp "${TMPDIR:-/tmp}/gion-shell-action.XXXXXX")" || return $?
-  GION_SHELL_ACTION_FILE="$action_file" command gion "$@"
-  local status=$?
-  if [[ $status -eq 0 && -s "$action_file" ]]; then
-    source "$action_file"
-  fi
-  rm -f "$action_file"
-  return $status
-}
-
-gion() {
-  __gion_run "$@"
-}
-
 _gion_completion() {
   local cur prev words cword
   _init_completion || return
 
-  local commands="init doctor repo manifest plan import apply version help completion"
+  local commands="init doctor repo manifest plan import apply shell version help completion"
   local manifest_subcmds="ls add rm gc validate preset"
   local manifest_aliases="man m"
   local preset_subcmds="ls add rm validate"
   local preset_aliases="pre p"
   local repo_subcmds="get ls rm"
+  local shell_subcmds="init completion"
 
   if [[ ${cword} -eq 1 ]]; then
     COMPREPLY=($(compgen -W "${commands} ${manifest_aliases}" -- "${cur}"))
@@ -112,6 +111,22 @@ _gion_completion() {
       COMPREPLY=($(compgen -W "--fix --self" -- "${cur}"))
       return
     ;;
+    shell)
+      if [[ ${cword} -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "${shell_subcmds}" -- "${cur}"))
+        return
+      fi
+      case ${words[2]} in
+        init)
+          COMPREPLY=($(compgen -W "--with-completion bash zsh" -- "${cur}"))
+          return
+        ;;
+        completion)
+          COMPREPLY=($(compgen -W "bash zsh" -- "${cur}"))
+          return
+        ;;
+      esac
+    ;;
     completion)
       if [[ ${cword} -eq 2 ]]; then
         COMPREPLY=($(compgen -W "bash zsh" -- "${cur}"))
@@ -131,18 +146,6 @@ complete -F _gion_completion gion`)
 func printZshCompletion(w io.Writer) {
 	fmt.Fprintln(w, `#compdef gion
 
-gion() {
-  local action_file
-  action_file="$(mktemp "${TMPDIR:-/tmp}/gion-shell-action.XXXXXX")" || return $?
-  GION_SHELL_ACTION_FILE="$action_file" command gion "$@"
-  local status=$?
-  if [[ $status -eq 0 && -s "$action_file" ]]; then
-    source "$action_file"
-  fi
-  rm -f "$action_file"
-  return $status
-}
-
 _gion() {
   local -a commands
   commands=(
@@ -153,6 +156,7 @@ _gion() {
     'plan:show manifest diff'
     'import:rebuild manifest from filesystem'
     'apply:apply manifest to filesystem'
+    'shell:shell integration commands'
     'version:print version'
     'help:show help'
     'completion:generate shell completion'
@@ -165,6 +169,12 @@ _gion() {
     'get:fetch or update bare repo store'
     'ls:list known bare repo stores'
     'rm:remove bare repo stores'
+  )
+
+  local -a shell_subcmds
+  shell_subcmds=(
+    'init:print shell integration script'
+    'completion:print shell completion script'
   )
 
   local -a manifest_subcmds
@@ -258,6 +268,19 @@ _gion() {
         doctor)
           _arguments '--fix[list issues and planned fixes]' '--self[run self-diagnostics]'
         ;;
+        shell)
+          case ${words[2]} in
+            init)
+              _arguments '--with-completion[append shell completion]' '1:shell:(bash zsh)'
+            ;;
+            completion)
+              _arguments '1:shell:(bash zsh)'
+            ;;
+            *)
+              _describe 'shell subcommand' shell_subcmds
+            ;;
+          esac
+        ;;
         completion)
           _values 'shell' bash zsh
         ;;
@@ -267,4 +290,16 @@ _gion() {
 }
 
 compdef _gion gion`)
+}
+
+type stringWriter struct {
+	b strings.Builder
+}
+
+func (w *stringWriter) Write(p []byte) (int, error) {
+	return w.b.Write(p)
+}
+
+func (w *stringWriter) String() string {
+	return w.b.String()
 }

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -27,6 +27,22 @@ func runCompletion(args []string) error {
 
 func printBashCompletion(w io.Writer) {
 	fmt.Fprintln(w, `# gion bash completion
+__gion_run() {
+  local action_file
+  action_file="$(mktemp "${TMPDIR:-/tmp}/gion-shell-action.XXXXXX")" || return $?
+  GION_SHELL_ACTION_FILE="$action_file" command gion "$@"
+  local status=$?
+  if [[ $status -eq 0 && -s "$action_file" ]]; then
+    source "$action_file"
+  fi
+  rm -f "$action_file"
+  return $status
+}
+
+gion() {
+  __gion_run "$@"
+}
+
 _gion_completion() {
   local cur prev words cword
   _init_completion || return
@@ -114,6 +130,18 @@ complete -F _gion_completion gion`)
 
 func printZshCompletion(w io.Writer) {
 	fmt.Fprintln(w, `#compdef gion
+
+gion() {
+  local action_file
+  action_file="$(mktemp "${TMPDIR:-/tmp}/gion-shell-action.XXXXXX")" || return $?
+  GION_SHELL_ACTION_FILE="$action_file" command gion "$@"
+  local status=$?
+  if [[ $status -eq 0 && -s "$action_file" ]]; then
+    source "$action_file"
+  fi
+  rm -f "$action_file"
+  return $status
+}
 
 _gion() {
   local -a commands

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -14,8 +14,8 @@ func TestPrintBashCompletion(t *testing.T) {
 	if !strings.Contains(output, "_gion_completion") {
 		t.Error("missing _gion_completion function")
 	}
-	if !strings.Contains(output, "GION_SHELL_ACTION_FILE") {
-		t.Error("missing shell action wrapper")
+	if strings.Contains(output, "GION_SHELL_ACTION_FILE") {
+		t.Error("completion should not include shell action wrapper")
 	}
 	if !strings.Contains(output, "complete -F _gion_completion gion") {
 		t.Error("missing complete command")
@@ -30,8 +30,8 @@ func TestPrintZshCompletion(t *testing.T) {
 	if !strings.Contains(output, "#compdef gion") {
 		t.Error("missing #compdef directive")
 	}
-	if !strings.Contains(output, "GION_SHELL_ACTION_FILE") {
-		t.Error("missing shell action wrapper")
+	if strings.Contains(output, "GION_SHELL_ACTION_FILE") {
+		t.Error("completion should not include shell action wrapper")
 	}
 	if !strings.Contains(output, "_gion") {
 		t.Error("missing _gion function")

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -14,6 +14,9 @@ func TestPrintBashCompletion(t *testing.T) {
 	if !strings.Contains(output, "_gion_completion") {
 		t.Error("missing _gion_completion function")
 	}
+	if !strings.Contains(output, "GION_SHELL_ACTION_FILE") {
+		t.Error("missing shell action wrapper")
+	}
 	if !strings.Contains(output, "complete -F _gion_completion gion") {
 		t.Error("missing complete command")
 	}
@@ -26,6 +29,9 @@ func TestPrintZshCompletion(t *testing.T) {
 
 	if !strings.Contains(output, "#compdef gion") {
 		t.Error("missing #compdef directive")
+	}
+	if !strings.Contains(output, "GION_SHELL_ACTION_FILE") {
+		t.Error("missing shell action wrapper")
 	}
 	if !strings.Contains(output, "_gion") {
 		t.Error("missing _gion function")

--- a/internal/cli/giongo.go
+++ b/internal/cli/giongo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/tasuku43/gion/internal/domain/workspace"
 	"github.com/tasuku43/gion/internal/infra/paths"
+	"github.com/tasuku43/gion/internal/infra/shellaction"
 	"github.com/tasuku43/gion/internal/ui"
 )
 
@@ -98,8 +99,7 @@ func RunGiongo() error {
 		if strings.TrimSpace(selected) == "" {
 			return nil
 		}
-		fmt.Fprintln(os.Stdout, selected)
-		return nil
+		return finalizeGiongoSelection(selected, true)
 	}
 	selected, err := ui.PromptWorkspaceRepoSelectWithOutput("giongo", choices, theme, useColor, out)
 	if err != nil {
@@ -111,10 +111,7 @@ func RunGiongo() error {
 	if strings.TrimSpace(selected) == "" {
 		return nil
 	}
-	if printFlag {
-		fmt.Fprintln(os.Stdout, selected)
-	}
-	return nil
+	return finalizeGiongoSelection(selected, printFlag)
 }
 
 func runGiongoInit(args []string) error {
@@ -179,13 +176,37 @@ func giongoInitScriptFor(rcFile string) string {
 		"    command giongo \"$@\"",
 		"    return $?",
 		"  fi",
-		"  local dest",
-		"  dest=\"$(command giongo --print \"$@\")\" || return $?",
-		"  [[ -n \"$dest\" ]] && cd \"$dest\"",
+		"  local __gion_action_file __gion_status",
+		"  __gion_action_file=\"$(mktemp \"${TMPDIR:-/tmp}/gion-shell-action.XXXXXX\")\" || return 1",
+		"  GION_SHELL_ACTION_FILE=\"$__gion_action_file\" command giongo \"$@\"",
+		"  __gion_status=$?",
+		"  if [ $__gion_status -ne 0 ]; then",
+		"    rm -f \"$__gion_action_file\"",
+		"    return $__gion_status",
+		"  fi",
+		"  if [ -s \"$__gion_action_file\" ]; then",
+		"    eval \"$(cat \"$__gion_action_file\")\"",
+		"  fi",
+		"  rm -f \"$__gion_action_file\"",
 		"}",
 		"",
 	}
 	return strings.Join(lines, "\n")
+}
+
+func finalizeGiongoSelection(selected string, print bool) error {
+	selected = strings.TrimSpace(selected)
+	if selected == "" {
+		return nil
+	}
+	if print {
+		fmt.Fprintln(os.Stdout, selected)
+		return nil
+	}
+	if err := shellaction.EmitCD(selected); err != nil {
+		return err
+	}
+	return nil
 }
 
 func buildGiongoWorkspaceChoices(ctx context.Context, entries []workspace.Entry) ([]ui.WorkspaceChoice, error) {

--- a/internal/cli/giongo_init_test.go
+++ b/internal/cli/giongo_init_test.go
@@ -16,8 +16,8 @@ func TestGiongoInitScriptForZsh(t *testing.T) {
 	if !strings.Contains(script, "command giongo \"$@\"") {
 		t.Fatalf("expected init bypass")
 	}
-	if !strings.Contains(script, "command giongo --print") {
-		t.Fatalf("expected --print wrapper")
+	if !strings.Contains(script, "GION_SHELL_ACTION_FILE") {
+		t.Fatalf("expected action-file wrapper")
 	}
 }
 

--- a/internal/cli/giongo_test.go
+++ b/internal/cli/giongo_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tasuku43/gion/internal/infra/shellaction"
 )
 
 func TestRunGiongoRequiresTTY(t *testing.T) {
@@ -43,5 +47,45 @@ func TestRunGiongoPrintUsesStderr(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "TTY") {
 		t.Fatalf("expected TTY error, got %q", err.Error())
+	}
+}
+
+func TestFinalizeGiongoSelection_PrintsWhenRequested(t *testing.T) {
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	if err := finalizeGiongoSelection("/tmp/example", true); err != nil {
+		t.Fatalf("finalizeGiongoSelection() error: %v", err)
+	}
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom() error: %v", err)
+	}
+	if strings.TrimSpace(buf.String()) != "/tmp/example" {
+		t.Fatalf("stdout = %q", buf.String())
+	}
+}
+
+func TestFinalizeGiongoSelection_EmitsShellAction(t *testing.T) {
+	actionFile := filepath.Join(t.TempDir(), "action.sh")
+	t.Setenv(shellaction.FileEnv, actionFile)
+
+	if err := finalizeGiongoSelection("/tmp/example", false); err != nil {
+		t.Fatalf("finalizeGiongoSelection() error: %v", err)
+	}
+
+	data, err := os.ReadFile(actionFile)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "builtin cd -- '/tmp/example'\n" {
+		t.Fatalf("action file = %q", string(data))
 	}
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -31,6 +31,7 @@ func printGlobalHelp(w io.Writer) {
 	fmt.Fprintln(w, helpCommand(theme, useColor, "import", fmt.Sprintf("rebuild %s from filesystem", manifest.FileName)))
 	fmt.Fprintln(w, helpCommand(theme, useColor, "apply", fmt.Sprintf("apply %s to filesystem", manifest.FileName)))
 	fmt.Fprintln(w, helpCommand(theme, useColor, "repo <subcommand>", "repo commands (get/ls/rm)"))
+	fmt.Fprintln(w, helpCommand(theme, useColor, "shell <subcommand>", "shell integration commands"))
 	fmt.Fprintln(w, helpCommand(theme, useColor, "doctor [--fix | --self]", "check workspace/repo health"))
 	fmt.Fprintln(w, helpCommand(theme, useColor, "completion [shell]", fmt.Sprintf("generate shell completion (%s)", SupportedShells)))
 	fmt.Fprintln(w, helpCommand(theme, useColor, "version", "print version"))
@@ -62,6 +63,8 @@ func printCommandHelp(cmd string, w io.Writer) bool {
 		printInitHelp(w)
 	case "completion":
 		printCompletionHelp(w)
+	case "shell":
+		printShellHelp(w)
 	case "version":
 		printVersion(w)
 	default:
@@ -216,11 +219,25 @@ func printCompletionHelp(w io.Writer) {
 	fmt.Fprintln(w, helpFlag(theme, useColor, "zsh", "generate zsh completion"))
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, helpSectionTitle(theme, useColor, "Usage:"))
-	fmt.Fprintln(w, "  # bash - add to ~/.bashrc")
-	fmt.Fprintln(w, "  eval \"$(gion completion bash)\"")
+	fmt.Fprintln(w, "  source <(gion completion bash)")
 	fmt.Fprintln(w, "")
-	fmt.Fprintln(w, "  # zsh - add to ~/.zshrc")
-	fmt.Fprintln(w, "  eval \"$(gion completion zsh)\"")
+	fmt.Fprintln(w, "  source <(gion completion zsh)")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Shell integration is handled separately by `gion shell init`.")
+}
+
+func printShellHelp(w io.Writer) {
+	theme, useColor := helpTheme(w)
+	fmt.Fprintln(w, "Usage: gion shell <subcommand>")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, helpSectionTitle(theme, useColor, "Subcommands:"))
+	fmt.Fprintln(w, helpCommand(theme, useColor, "init [shell] [--with-completion]", "print shell integration script"))
+	fmt.Fprintln(w, helpCommand(theme, useColor, "completion [shell]", fmt.Sprintf("print shell completion script (%s)", SupportedShells)))
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, helpSectionTitle(theme, useColor, "Usage:"))
+	fmt.Fprintln(w, "  eval \"$(gion shell init zsh)\"")
+	fmt.Fprintln(w, "  eval \"$(gion shell init zsh --with-completion)\"")
+	fmt.Fprintln(w, "  source <(gion shell completion zsh)")
 }
 
 func printImportHelp(w io.Writer) {

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -144,5 +144,24 @@ gion() {
   fi
   rm -f "$__gion_action_file"
 }
+
+giongo() {
+  if [ "$1" = "init" ] || [ "$1" = "--help" ] || [ "$1" = "-h" ] || [ "$1" = "--version" ] || [ "$1" = "--print" ]; then
+    command giongo "$@"
+    return $?
+  fi
+  local __gion_action_file __gion_status
+  __gion_action_file="$(mktemp "${TMPDIR:-/tmp}/gion-shell-action.XXXXXX")" || return 1
+  GION_SHELL_ACTION_FILE="$__gion_action_file" command giongo "$@"
+  __gion_status=$?
+  if [ $__gion_status -ne 0 ]; then
+    rm -f "$__gion_action_file"
+    return $__gion_status
+  fi
+  if [ -s "$__gion_action_file" ]; then
+    eval "$(cat "$__gion_action_file")"
+  fi
+  rm -f "$__gion_action_file"
+}
 `, shellName, shellName), nil
 }

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func runShell(args []string) error {
+	if len(args) == 0 {
+		printShellHelp(os.Stdout)
+		return nil
+	}
+
+	switch strings.TrimSpace(args[0]) {
+	case "-h", "--help", "help":
+		printShellHelp(os.Stdout)
+		return nil
+	case "init":
+		return runShellInit(args[1:])
+	case "completion":
+		return runShellCompletion(args[1:])
+	default:
+		return fmt.Errorf("unknown shell command: %s", args[0])
+	}
+}
+
+func runShellInit(args []string) error {
+	shellName := ""
+	withCompletion := false
+	rest := append([]string{}, args...)
+	for len(rest) > 0 {
+		cur := strings.TrimSpace(rest[0])
+		switch cur {
+		case "-h", "--help", "help":
+			printShellHelp(os.Stdout)
+			return nil
+		case "--with-completion":
+			withCompletion = true
+			rest = rest[1:]
+		default:
+			if strings.HasPrefix(cur, "--with-completion=") {
+				value := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(cur, "--with-completion=")))
+				switch value {
+				case "1", "true", "yes", "on":
+					withCompletion = true
+				case "0", "false", "no", "off":
+					withCompletion = false
+				default:
+					return fmt.Errorf("invalid --with-completion value: %q (supported: true/false)", value)
+				}
+				rest = rest[1:]
+				continue
+			}
+			if strings.HasPrefix(cur, "-") {
+				return fmt.Errorf("unknown flag for shell init: %q", cur)
+			}
+			if shellName != "" {
+				return fmt.Errorf("unexpected args for shell init: %q", strings.Join(rest, " "))
+			}
+			shellName = cur
+			rest = rest[1:]
+		}
+	}
+
+	if shellName == "" {
+		shellName = detectShellName()
+	}
+	if shellName == "" {
+		shellName = "zsh"
+	}
+
+	script, err := renderShellInitScript(shellName, withCompletion)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(os.Stdout, script)
+	return nil
+}
+
+func runShellCompletion(args []string) error {
+	shellName := ""
+	if len(args) > 1 {
+		return fmt.Errorf("unexpected args for shell completion: %q", strings.Join(args[1:], " "))
+	}
+	if len(args) == 1 {
+		shellName = strings.TrimSpace(args[0])
+	} else {
+		shellName = detectShellName()
+	}
+	if shellName == "" {
+		shellName = "zsh"
+	}
+	return runCompletion([]string{shellName})
+}
+
+func detectShellName() string {
+	raw := strings.TrimSpace(os.Getenv("SHELL"))
+	if raw == "" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(filepath.Base(raw)))
+}
+
+func renderShellInitScript(shellName string, withCompletion bool) (string, error) {
+	initScript, err := renderPOSIXShellInitScript(shellName)
+	if err != nil {
+		return "", err
+	}
+	if !withCompletion {
+		return initScript, nil
+	}
+	completionScript, err := renderShellCompletionScript(shellName)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasSuffix(initScript, "\n") {
+		return initScript + "\n" + completionScript, nil
+	}
+	return initScript + "\n\n" + completionScript, nil
+}
+
+func renderPOSIXShellInitScript(shellName string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(shellName)) {
+	case "zsh", "bash", "sh":
+	default:
+		return "", fmt.Errorf("unsupported shell: %s (supported: %s)", shellName, SupportedShells)
+	}
+	return fmt.Sprintf(`# gion shell integration (%s)
+# Add this line to your shell rc file, then restart the shell:
+#   eval "$(gion shell init %s)"
+gion() {
+  local __gion_action_file __gion_status
+  __gion_action_file="$(mktemp "${TMPDIR:-/tmp}/gion-shell-action.XXXXXX")" || return 1
+  GION_SHELL_ACTION_FILE="$__gion_action_file" command gion "$@"
+  __gion_status=$?
+  if [ $__gion_status -ne 0 ]; then
+    rm -f "$__gion_action_file"
+    return $__gion_status
+  fi
+  if [ -s "$__gion_action_file" ]; then
+    eval "$(cat "$__gion_action_file")"
+  fi
+  rm -f "$__gion_action_file"
+}
+`, shellName, shellName), nil
+}

--- a/internal/cli/shell_test.go
+++ b/internal/cli/shell_test.go
@@ -30,6 +30,9 @@ func TestRunShellInit_WithCompletion(t *testing.T) {
 	if !strings.Contains(output, "GION_SHELL_ACTION_FILE") {
 		t.Fatalf("shell init output missing action wrapper: %q", output)
 	}
+	if !strings.Contains(output, "giongo() {") {
+		t.Fatalf("shell init output missing giongo wrapper: %q", output)
+	}
 	if !strings.Contains(output, "#compdef gion") {
 		t.Fatalf("shell init output missing zsh completion: %q", output)
 	}

--- a/internal/cli/shell_test.go
+++ b/internal/cli/shell_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRunShellInit_WithCompletion(t *testing.T) {
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = stdout })
+
+	err = runShell([]string{"init", "zsh", "--with-completion"})
+	if err != nil {
+		t.Fatalf("runShell(init) error: %v", err)
+	}
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom() error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "GION_SHELL_ACTION_FILE") {
+		t.Fatalf("shell init output missing action wrapper: %q", output)
+	}
+	if !strings.Contains(output, "#compdef gion") {
+		t.Fatalf("shell init output missing zsh completion: %q", output)
+	}
+}
+
+func TestRunShellCompletion(t *testing.T) {
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = stdout })
+
+	err = runShell([]string{"completion", "bash"})
+	if err != nil {
+		t.Fatalf("runShell(completion) error: %v", err)
+	}
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom() error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "_gion_completion") {
+		t.Fatalf("shell completion output missing bash completion: %q", output)
+	}
+	if strings.Contains(output, "GION_SHELL_ACTION_FILE") {
+		t.Fatalf("shell completion should not include shell wrapper: %q", output)
+	}
+}
+
+func TestRunShellInit_InvalidWithCompletionValue(t *testing.T) {
+	err := runShellInit([]string{"zsh", "--with-completion=maybe"})
+	if err == nil {
+		t.Fatal("expected error for invalid --with-completion value")
+	}
+}

--- a/internal/domain/workspace/remove.go
+++ b/internal/domain/workspace/remove.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tasuku43/gion/internal/infra/gitcmd"
 	"github.com/tasuku43/gion/internal/infra/paths"
+	"github.com/tasuku43/gion/internal/infra/shellaction"
 )
 
 type RemoveOptions struct {
@@ -37,7 +38,8 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 	} else if !exists {
 		return fmt.Errorf("workspace does not exist: %s", wsDir)
 	}
-	if err := shiftCWDToRootIfInsideWorkspace(rootDir, wsDir); err != nil {
+	shifted, err := shiftCWDToRootIfInsideWorkspace(rootDir, wsDir)
+	if err != nil {
 		return err
 	}
 
@@ -87,25 +89,30 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 	if err := os.RemoveAll(wsDir); err != nil {
 		return fmt.Errorf("remove workspace dir: %w", err)
 	}
+	if shifted {
+		if err := shellaction.EmitCD(rootDir); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
 
-func shiftCWDToRootIfInsideWorkspace(rootDir, workspaceDir string) error {
+func shiftCWDToRootIfInsideWorkspace(rootDir, workspaceDir string) (bool, error) {
 	if strings.TrimSpace(rootDir) == "" || strings.TrimSpace(workspaceDir) == "" {
-		return nil
+		return false, nil
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("get working dir: %w", err)
+		return false, fmt.Errorf("get working dir: %w", err)
 	}
 	if !pathInside(workspaceDir, cwd) {
-		return nil
+		return false, nil
 	}
 	if err := os.Chdir(rootDir); err != nil {
-		return fmt.Errorf("shift process cwd to root: %w", err)
+		return false, fmt.Errorf("shift process cwd to root: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 func pathInside(base, target string) bool {

--- a/internal/domain/workspace/repo_workspace_test.go
+++ b/internal/domain/workspace/repo_workspace_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tasuku43/gion/internal/domain/repo"
 	"github.com/tasuku43/gion/internal/domain/workspace"
+	"github.com/tasuku43/gion/internal/infra/shellaction"
 )
 
 func TestRepoGetWorkspaceAddRemove(t *testing.T) {
@@ -137,6 +138,8 @@ func TestWorkspaceRemoveShiftsProcessCWDWhenInsideTargetWorkspace(t *testing.T) 
 		t.Fatalf("Getwd() error: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(origWD) })
+	actionFile := filepath.Join(t.TempDir(), "action.sh")
+	t.Setenv(shellaction.FileEnv, actionFile)
 
 	worktreePath := workspace.WorktreePath(rootDir, "WS-1", "repo")
 	if err := os.Chdir(worktreePath); err != nil {
@@ -161,6 +164,14 @@ func TestWorkspaceRemoveShiftsProcessCWDWhenInsideTargetWorkspace(t *testing.T) 
 	}
 	if afterResolved != rootResolved {
 		t.Fatalf("process cwd = %q (resolved=%q), want %q (resolved=%q)", afterWD, afterResolved, rootDir, rootResolved)
+	}
+	actionData, err := os.ReadFile(actionFile)
+	if err != nil {
+		t.Fatalf("ReadFile(action) error: %v", err)
+	}
+	wantAction := fmt.Sprintf("builtin cd -- '%s'\n", rootDir)
+	if string(actionData) != wantAction {
+		t.Fatalf("shell action = %q, want %q", string(actionData), wantAction)
 	}
 }
 

--- a/internal/infra/shellaction/shellaction.go
+++ b/internal/infra/shellaction/shellaction.go
@@ -1,0 +1,29 @@
+package shellaction
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const FileEnv = "GION_SHELL_ACTION_FILE"
+
+func EmitCD(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	target := strings.TrimSpace(os.Getenv(FileEnv))
+	if target == "" {
+		return nil
+	}
+	line := fmt.Sprintf("builtin cd -- %s\n", shellQuote(path))
+	if err := os.WriteFile(target, []byte(line), 0o600); err != nil {
+		return fmt.Errorf("write shell action file: %w", err)
+	}
+	return nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}

--- a/internal/infra/shellaction/shellaction_test.go
+++ b/internal/infra/shellaction/shellaction_test.go
@@ -1,0 +1,31 @@
+package shellaction
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEmitCDWritesShellActionFile(t *testing.T) {
+	actionFile := filepath.Join(t.TempDir(), "action.sh")
+	t.Setenv(FileEnv, actionFile)
+
+	if err := EmitCD("/tmp/example dir"); err != nil {
+		t.Fatalf("EmitCD() error: %v", err)
+	}
+
+	got, err := os.ReadFile(actionFile)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	want := "builtin cd -- '/tmp/example dir'\n"
+	if string(got) != want {
+		t.Fatalf("shell action = %q, want %q", string(got), want)
+	}
+}
+
+func TestEmitCDSkipsWhenEnvMissing(t *testing.T) {
+	if err := EmitCD("/tmp/example"); err != nil {
+		t.Fatalf("EmitCD() error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- emit a shell action to return the parent shell to GION_ROOT after successful workspace removal
- extend `gion completion bash|zsh` to install the shell wrapper that applies action files
- document shell sync behavior and add regression coverage

## Testing
- go test ./...
- go vet ./...
- go build ./...