### PR TITLE
Add workspace remove recovery state

### DIFF
--- a/docs/spec/commands/apply.md
+++ b/docs/spec/commands/apply.md
@@ -26,6 +26,13 @@ Reconcile the filesystem to match `gion.yaml` by computing a diff, showing a pla
 - During destructive workspace removal, if the current process cwd is inside `workspaces/<id>/...`, gion must first shift process cwd to `<root>` before any worktree removal starts.
   - When shell integration from `gion shell init` is active, successful workspace removal must emit a shell action that changes the parent shell cwd to `<root>`.
   - On failure, gion must not emit a shell action.
+- During destructive workspace removal, gion must persist transient operation state at `<root>/.gion/state/operations/workspace-remove/<workspace-id>.json`.
+  - The state file tracks which repo aliases were already removed and whether the workspace directory is still present.
+  - The state file is operational metadata only; it is not part of the canonical manifest inventory and must not be imported into `gion.yaml`.
+  - On successful workspace removal, gion must delete the state file.
+- Before applying a destructive workspace removal, gion must check for an existing unfinished state file for that workspace.
+  - If one exists, `gion apply` must fail fast before starting any new destructive work for that workspace.
+  - The error must identify the workspace and summarize the partial progress so the user can inspect the unfinished removal state.
 - When applying `add` actions that require creating a new branch:
   - If the target `branch` already exists in the bare store, gion checks it out when adding the worktree.
   - If the branch does not exist, gion creates it from:
@@ -51,3 +58,4 @@ Reconcile the filesystem to match `gion.yaml` by computing a diff, showing a pla
 - Manifest file missing or invalid.
 - Filesystem or git errors while applying actions.
 - `--no-prompt` used with destructive actions.
+- Unfinished workspace removal state already exists at `<root>/.gion/state/operations/workspace-remove/<workspace-id>.json`.

--- a/internal/app/apply/apply.go
+++ b/internal/app/apply/apply.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,6 +33,9 @@ func Apply(ctx context.Context, rootDir string, plan manifestplan.Result, opts O
 	for _, change := range execPlan.WorkspaceRemovals {
 		if change.Kind != manifestplan.WorkspaceRemove {
 			continue
+		}
+		if err := ensureNoIncompleteWorkspaceRemoval(rootDir, change.WorkspaceID); err != nil {
+			return err
 		}
 		logStep(opts.Step, fmt.Sprintf("remove workspace %s", change.WorkspaceID))
 		if err := rm.Remove(ctx, rootDir, change.WorkspaceID, opts.AllowDirty); err != nil {
@@ -255,6 +259,22 @@ func logStep(step func(text string), text string) {
 		return
 	}
 	step(text)
+}
+
+func ensureNoIncompleteWorkspaceRemoval(rootDir, workspaceID string) error {
+	state, ok, err := workspace.LoadRemoveState(rootDir, workspaceID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"workspace removal is incomplete for %s: %s; inspect %s and resolve the partial state before retrying gion apply",
+		workspaceID,
+		state.Summary(),
+		filepath.Join(rootDir, workspace.MetadataDirName, "state", "operations", "workspace-remove", workspaceID+".json"),
+	)
 }
 
 func desiredBaseRef(desired manifest.File, workspaceID, alias string) string {

--- a/internal/app/apply/apply_test.go
+++ b/internal/app/apply/apply_test.go
@@ -1,9 +1,14 @@
 package apply
 
 import (
+	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	coreapplyplan "github.com/tasuku43/gion-core/applyplan"
+	"github.com/tasuku43/gion/internal/app/manifestplan"
+	"github.com/tasuku43/gion/internal/domain/workspace"
 )
 
 func TestUpdateBaseBranchCandidate(t *testing.T) {
@@ -67,5 +72,33 @@ func TestUpdateBaseBranchCandidate(t *testing.T) {
 				t.Fatalf("mixed: got %v, want %v", gotMixed, tt.wantMixed)
 			}
 		})
+	}
+}
+
+func TestApplyFailsFastWhenWorkspaceRemoveStateExists(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	if err := workspace.SaveRemoveState(rootDir, workspace.NewRemoveState("WS-1", []string{"repo-a", "repo-b"}, true)); err != nil {
+		t.Fatalf("SaveRemoveState() error = %v", err)
+	}
+
+	err := Apply(context.Background(), rootDir, manifestplan.Result{
+		Changes: []manifestplan.WorkspaceChange{
+			{
+				Kind:        manifestplan.WorkspaceRemove,
+				WorkspaceID: "WS-1",
+			},
+		},
+	}, Options{})
+	if err == nil {
+		t.Fatalf("Apply() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "workspace removal is incomplete for WS-1") {
+		t.Fatalf("Apply() error = %v, want incomplete removal message", err)
+	}
+	wantPath := filepath.Join(rootDir, workspace.MetadataDirName, "state", "operations", "workspace-remove", "WS-1.json")
+	if !strings.Contains(err.Error(), wantPath) {
+		t.Fatalf("Apply() error = %v, want path %q", err, wantPath)
 	}
 }

--- a/internal/domain/workspace/remove.go
+++ b/internal/domain/workspace/remove.go
@@ -17,6 +17,12 @@ type RemoveOptions struct {
 	AllowDirty       bool
 }
 
+var (
+	worktreeRemoveFn    = gitcmd.WorktreeRemove
+	removeWorkspaceFn   = os.RemoveAll
+	deleteRemoveStateFn = DeleteRemoveState
+)
+
 func Remove(ctx context.Context, rootDir, workspaceID string) error {
 	return RemoveWithOptions(ctx, rootDir, workspaceID, RemoveOptions{})
 }
@@ -48,6 +54,10 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 		return err
 	}
 	_ = warnings
+	aliases := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		aliases = append(aliases, repo.Alias)
+	}
 
 	for _, repo := range repos {
 		if repo.WorktreePath == "" {
@@ -68,6 +78,11 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 		}
 	}
 
+	state := NewRemoveState(workspaceID, aliases, true)
+	if err := SaveRemoveState(rootDir, state); err != nil {
+		return err
+	}
+
 	for _, repo := range repos {
 		if repo.StorePath == "" {
 			continue
@@ -81,13 +96,37 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 		} else {
 			gitcmd.Logf("git worktree remove %s", repo.WorktreePath)
 		}
-		if err := gitcmd.WorktreeRemove(ctx, repo.StorePath, repo.WorktreePath, force); err != nil {
+		if err := worktreeRemoveFn(ctx, repo.StorePath, repo.WorktreePath, force); err != nil {
+			state.LastError = fmt.Sprintf("remove worktree %q: %v", repo.Alias, err)
+			state.UpdatedAt = removeStateNow()
+			if saveErr := SaveRemoveState(rootDir, state); saveErr != nil {
+				return fmt.Errorf("remove worktree %q: %w (also failed to save remove state: %v)", repo.Alias, err, saveErr)
+			}
 			return fmt.Errorf("remove worktree %q: %w", repo.Alias, err)
+		}
+		state.RemovedAliases = append(state.RemovedAliases, repo.Alias)
+		state.PendingAliases = removePendingAlias(state.PendingAliases, repo.Alias)
+		state.UpdatedAt = removeStateNow()
+		state.LastError = ""
+		if err := SaveRemoveState(rootDir, state); err != nil {
+			return err
 		}
 	}
 
-	if err := os.RemoveAll(wsDir); err != nil {
+	if err := removeWorkspaceFn(wsDir); err != nil {
+		state.WorkspaceDirPresent = true
+		state.LastError = fmt.Sprintf("remove workspace dir: %v", err)
+		state.UpdatedAt = removeStateNow()
+		if saveErr := SaveRemoveState(rootDir, state); saveErr != nil {
+			return fmt.Errorf("remove workspace dir: %w (also failed to save remove state: %v)", err, saveErr)
+		}
 		return fmt.Errorf("remove workspace dir: %w", err)
+	}
+	state.WorkspaceDirPresent = false
+	state.LastError = ""
+	state.UpdatedAt = removeStateNow()
+	if err := deleteRemoveStateFn(rootDir, workspaceID); err != nil {
+		return err
 	}
 	if shifted {
 		if err := shellaction.EmitCD(rootDir); err != nil {
@@ -136,4 +175,19 @@ func pathInside(base, target string) bool {
 		return true
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func removePendingAlias(pending []string, alias string) []string {
+	next := make([]string, 0, len(pending))
+	for _, candidate := range pending {
+		if candidate == alias {
+			continue
+		}
+		next = append(next, candidate)
+	}
+	return next
+}
+
+func removeStateNow() string {
+	return removeStateTimestamp()
 }

--- a/internal/domain/workspace/remove_state.go
+++ b/internal/domain/workspace/remove_state.go
@@ -1,0 +1,143 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	removeStateDirMode  = 0o750
+	removeStateFileMode = 0o600
+)
+
+type RemoveState struct {
+	WorkspaceID         string   `json:"workspace_id"`
+	StartedAt           string   `json:"started_at"`
+	UpdatedAt           string   `json:"updated_at"`
+	ReposTotal          int      `json:"repos_total"`
+	RemovedAliases      []string `json:"removed_aliases"`
+	PendingAliases      []string `json:"pending_aliases"`
+	WorkspaceDirPresent bool     `json:"workspace_dir_present"`
+	LastError           string   `json:"last_error,omitempty"`
+}
+
+func LoadRemoveState(rootDir, workspaceID string) (RemoveState, bool, error) {
+	path, err := removeStatePath(rootDir, workspaceID)
+	if err != nil {
+		return RemoveState{}, false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return RemoveState{}, false, nil
+		}
+		return RemoveState{}, false, fmt.Errorf("read remove state: %w", err)
+	}
+	var state RemoveState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return RemoveState{}, false, fmt.Errorf("parse remove state: %w", err)
+	}
+	return normalizeRemoveState(state), true, nil
+}
+
+func SaveRemoveState(rootDir string, state RemoveState) error {
+	path, err := removeStatePath(rootDir, state.WorkspaceID)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, removeStateDirMode); err != nil {
+		return fmt.Errorf("create remove state dir: %w", err)
+	}
+	state = normalizeRemoveState(state)
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal remove state: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp remove state: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp remove state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp remove state: %w", err)
+	}
+	if err := os.Chmod(tmpName, removeStateFileMode); err != nil {
+		return fmt.Errorf("chmod temp remove state: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename remove state: %w", err)
+	}
+	return nil
+}
+
+func DeleteRemoveState(rootDir, workspaceID string) error {
+	path, err := removeStatePath(rootDir, workspaceID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete remove state: %w", err)
+	}
+	return nil
+}
+
+func removeStatePath(rootDir, workspaceID string) (string, error) {
+	if strings.TrimSpace(rootDir) == "" {
+		return "", fmt.Errorf("root directory is required")
+	}
+	if strings.TrimSpace(workspaceID) == "" {
+		return "", fmt.Errorf("workspace id is required")
+	}
+	if strings.ContainsAny(workspaceID, `/\`) {
+		return "", fmt.Errorf("invalid workspace id: must not contain path separators")
+	}
+	return filepath.Join(rootDir, MetadataDirName, "state", "operations", "workspace-remove", workspaceID+".json"), nil
+}
+
+func NewRemoveState(workspaceID string, aliases []string, workspaceDirPresent bool) RemoveState {
+	now := removeStateTimestamp()
+	return normalizeRemoveState(RemoveState{
+		WorkspaceID:         workspaceID,
+		StartedAt:           now,
+		UpdatedAt:           now,
+		ReposTotal:          len(aliases),
+		RemovedAliases:      nil,
+		PendingAliases:      append([]string(nil), aliases...),
+		WorkspaceDirPresent: workspaceDirPresent,
+	})
+}
+
+func (s RemoveState) Summary() string {
+	return fmt.Sprintf("removed=%v pending=%v workspace_dir_present=%t", s.RemovedAliases, s.PendingAliases, s.WorkspaceDirPresent)
+}
+
+func normalizeRemoveState(state RemoveState) RemoveState {
+	state.WorkspaceID = strings.TrimSpace(state.WorkspaceID)
+	state.StartedAt = strings.TrimSpace(state.StartedAt)
+	state.UpdatedAt = strings.TrimSpace(state.UpdatedAt)
+	state.LastError = strings.TrimSpace(state.LastError)
+	if state.RemovedAliases == nil {
+		state.RemovedAliases = []string{}
+	}
+	if state.PendingAliases == nil {
+		state.PendingAliases = []string{}
+	}
+	if state.ReposTotal == 0 {
+		state.ReposTotal = len(state.RemovedAliases) + len(state.PendingAliases)
+	}
+	return state
+}
+
+func removeStateTimestamp() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}

--- a/internal/domain/workspace/remove_state_test.go
+++ b/internal/domain/workspace/remove_state_test.go
@@ -1,0 +1,154 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tasuku43/gion/internal/domain/repo"
+)
+
+func TestRemoveDeletesRemoveStateOnSuccess(t *testing.T) {
+	t.Setenv("GIT_AUTHOR_NAME", "gion")
+	t.Setenv("GIT_AUTHOR_EMAIL", "gion@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "gion")
+	t.Setenv("GIT_COMMITTER_EMAIL", "gion@example.com")
+
+	ctx := context.Background()
+	rootDir, repoSpec := setupRemoveStateFixture(t, ctx)
+
+	if err := Remove(ctx, rootDir, "WS-1"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	path, err := removeStatePath(rootDir, "WS-1")
+	if err != nil {
+		t.Fatalf("removeStatePath() error = %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("remove state should be deleted, stat err = %v", err)
+	}
+	if _, err := os.Stat(WorkspaceDir(rootDir, "WS-1")); !os.IsNotExist(err) {
+		t.Fatalf("workspace should be deleted, stat err = %v", err)
+	}
+	if _, _, err := repo.Exists(rootDir, repoSpec); err != nil {
+		t.Fatalf("repo.Exists() error = %v", err)
+	}
+}
+
+func TestRemovePersistsPartialRemoveStateWhenWorkspaceDirDeleteFails(t *testing.T) {
+	t.Setenv("GIT_AUTHOR_NAME", "gion")
+	t.Setenv("GIT_AUTHOR_EMAIL", "gion@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "gion")
+	t.Setenv("GIT_COMMITTER_EMAIL", "gion@example.com")
+
+	ctx := context.Background()
+	rootDir, _ := setupRemoveStateFixture(t, ctx)
+
+	origRemoveWorkspaceFn := removeWorkspaceFn
+	removeWorkspaceFn = func(path string) error {
+		return fmt.Errorf("boom: cannot remove %s", path)
+	}
+	t.Cleanup(func() {
+		removeWorkspaceFn = origRemoveWorkspaceFn
+	})
+
+	err := Remove(ctx, rootDir, "WS-1")
+	if err == nil {
+		t.Fatalf("Remove() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "remove workspace dir") {
+		t.Fatalf("Remove() error = %v, want workspace dir error", err)
+	}
+
+	state, ok, err := LoadRemoveState(rootDir, "WS-1")
+	if err != nil {
+		t.Fatalf("LoadRemoveState() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("remove state should exist")
+	}
+	if got, want := state.RemovedAliases, []string{"repo"}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("RemovedAliases = %v, want %v", got, want)
+	}
+	if len(state.PendingAliases) != 0 {
+		t.Fatalf("PendingAliases = %v, want empty", state.PendingAliases)
+	}
+	if !state.WorkspaceDirPresent {
+		t.Fatalf("WorkspaceDirPresent = false, want true")
+	}
+	if !strings.Contains(state.LastError, "remove workspace dir") {
+		t.Fatalf("LastError = %q, want workspace dir message", state.LastError)
+	}
+	if _, err := os.Stat(WorkspaceDir(rootDir, "WS-1")); err != nil {
+		t.Fatalf("workspace should still exist, stat err = %v", err)
+	}
+}
+
+func setupRemoveStateFixture(t *testing.T, ctx context.Context) (string, string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	rootDir := filepath.Join(tmp, "gion")
+
+	remoteBase := filepath.Join(tmp, "remotes")
+	remotePath := filepath.Join(remoteBase, "org", "repo.git")
+	if err := os.MkdirAll(filepath.Dir(remotePath), 0o755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	runGitForRemoveState(t, "", "init", "--bare", remotePath)
+
+	seedDir := filepath.Join(tmp, "seed")
+	runGitForRemoveState(t, "", "init", seedDir)
+	runGitForRemoveState(t, seedDir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seedDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runGitForRemoveState(t, seedDir, "add", ".")
+	runGitForRemoveState(t, seedDir, "commit", "-m", "init")
+	runGitForRemoveState(t, seedDir, "remote", "add", "origin", remotePath)
+	runGitForRemoveState(t, seedDir, "push", "origin", "main")
+	runGitForRemoveState(t, "", "--git-dir", remotePath, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	configPath := filepath.Join(tmp, "gitconfig")
+	fileURL := "file://" + filepath.ToSlash(remoteBase) + "/"
+	configData := fmt.Sprintf("[url \"%s\"]\n\tinsteadOf = https://example.com/\n", fileURL)
+	if err := os.WriteFile(configPath, []byte(configData), 0o644); err != nil {
+		t.Fatalf("write gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
+
+	repoSpec := "https://example.com/org/repo.git"
+	if _, err := repo.Get(ctx, rootDir, repoSpec); err != nil {
+		t.Fatalf("repo get: %v", err)
+	}
+	if _, err := New(ctx, rootDir, "WS-1"); err != nil {
+		t.Fatalf("workspace new: %v", err)
+	}
+	if _, err := Add(ctx, rootDir, "WS-1", repoSpec, "", true); err != nil {
+		t.Fatalf("workspace add: %v", err)
+	}
+	return rootDir, repoSpec
+}
+
+func runGitForRemoveState(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary
- persist transient workspace removal state under `.gion/state/operations/workspace-remove/<workspace-id>.json`
- update `gion apply` to fail fast when an unfinished workspace removal state already exists
- add spec coverage and regression tests for successful cleanup and partial removal failure

## Testing
- go test ./...
- go vet ./...
- go build ./...