### PR TITLE
Align gion selector UI with kra-style interaction patterns

### DIFF
--- a/docs/spec/ui/UI-ARCH.md
+++ b/docs/spec/ui/UI-ARCH.md
@@ -11,6 +11,7 @@ This document describes the implementation structure (separation of concerns) th
 - Always guarantee the fixed section order: Inputs → Info → Steps → Result → Suggestion
 - Avoid per-command bespoke rendering; enforce the contract through shared components
 - Prevent duplicate Inputs output during interactive flows (update in-place instead)
+- Keep selector implementations aligned with [UI-SELECTOR.md](/Users/tasuku43/gionroot/workspaces/gion/gion/docs/spec/ui/UI-SELECTOR.md)
 
 ## Components
 
@@ -37,6 +38,7 @@ This document describes the implementation structure (separation of concerns) th
 **Responsibilities**
 - Input/selection state transitions and validation
 - `View()` should only update Inputs/Info via Frame
+- Selector-family behavior should be centralized here rather than duplicated in command handlers
 
 ## Implementation Rules
 - Do not print UI output directly with `fmt.Fprintf/Printf/Println` (use Renderer/Frame)
@@ -47,3 +49,4 @@ This document describes the implementation structure (separation of concerns) th
 ## Applying to Existing Flows
 - Prefer a single Frame that updates across multiple prompt steps
 - Use `AppendInputsRaw(...)` for list/tree lines to keep the section order intact
+- Treat selector copy, finish hints, and selected-set rendering as shared UI behavior, not per-command wording

--- a/docs/spec/ui/UI-SELECTOR.md
+++ b/docs/spec/ui/UI-SELECTOR.md
@@ -1,0 +1,184 @@
+---
+title: "Selector UI"
+status: proposed
+---
+
+# Selector UI
+
+This document defines the `gion` selector contract for interactive pickers.
+It intentionally aligns with `kra` on visual language and terminal layout, while
+keeping `gion`'s flow-oriented interaction model.
+
+## Goals
+
+- Make `gion` and `kra` feel like the same family in terminal UI quality
+- Preserve `gion`'s input-flow orientation for manifest and workspace creation flows
+- Reduce per-picker drift by documenting one selector contract for `gion`
+
+## Design stance
+
+`gion` selectors are not a direct copy of `kra` selectors.
+
+- `kra` favors in-list toggle interaction for repeated operational tasks
+- `gion` favors staged input flows that move the user toward one apply action
+
+Because of that, `gion` keeps its own selection model, but should reuse the same
+visual grammar where possible:
+
+- stable section layout
+- consistent filter input placement
+- consistent muted/accent/error semantics
+- consistent focus visibility
+- consistent key-hint language
+
+## Selector families
+
+`gion` currently uses two selector families.
+
+### Single-select
+
+Used when the next step needs exactly one value.
+
+Examples:
+- mode selection in create flows
+- repo selection in create flows
+- workspace selection in simple pickers
+- `giongo` workspace/repo selection
+
+Interaction:
+- `Up` / `Down`: move cursor
+- `Enter`: confirm focused row
+- `Esc` / `Ctrl+C`: cancel
+- typing: update filter query
+- `Backspace` / `Delete`: edit filter query
+
+### Multi-select
+
+Used when the user builds a set and then proceeds to the next step or apply.
+
+Examples:
+- review PR selection
+- issue selection
+- preset repo selection
+- manifest workspace removal selection
+
+Interaction:
+- `Up` / `Down`: move cursor
+- `Enter`: add the focused item into the selected set
+- `Ctrl+D`: finish selection
+- `done` + `Enter`: finish selection
+- `Esc` / `Ctrl+C`: cancel
+- typing: update filter query
+- `Backspace` / `Delete`: edit filter query
+
+Important distinction from `kra`:
+- `gion` multi-select is append-and-progress, not toggle-in-place
+- selected items may move out of the candidate list and into `Info`
+
+This is intentional and matches `gion`'s staged workflow design.
+
+## Shared layout contract
+
+Selectors must follow [UI.md](/Users/tasuku43/gionroot/workspaces/gion/gion/docs/spec/ui/UI.md).
+
+Rules:
+- keep selector content inside the shared `Frame`
+- selector input lives in `Inputs`
+- selected items, blocked items, and validation messages live in `Info`
+- do not introduce ad-hoc section names outside the shared section system
+- do not use AltScreen
+
+For selector rendering:
+- the filter input line stays at the top of `Inputs`
+- the candidate list is rendered immediately below the input line
+- helper text such as finish hints is rendered after the candidate list
+- selected items are rendered in `Info`
+- blocked items, when present, are rendered after selected items in `Info`
+
+## Visual language
+
+To keep the family resemblance with `kra`, selectors should converge on the
+same terminal language even when the interaction differs.
+
+### Focus
+
+- the focused row must be visually obvious
+- in color terminals, focused text may use bold and/or a subtle emphasis style
+- in no-color terminals, focus must remain understandable from row position alone
+
+### Selection state
+
+`gion` does not need to adopt `kra`'s `○/●` row markers everywhere.
+
+Instead:
+- candidate rows may remain compact and flow-oriented
+- the selected set must be visible as a separate list or tree in `Info`
+- the selected set should use accent for its heading and muted rendering for tree structure
+
+### Text hierarchy
+
+- primary information: selected item labels, focused row content
+- muted information: descriptions, tree connectors, helper text
+- error information: validation lines and blocking messages
+- accent information: selector labels and selected-set headings
+
+## Copy and hints
+
+Selector copy should be short and explicit.
+
+Recommended wording:
+- `finish: Ctrl+D or type "done"` for append-style multi-select
+- `select at least one <item>` for empty-confirm validation
+- `no matches` when filter results are empty
+
+`gion` may keep its own finish hint instead of adopting `kra`'s footer contract,
+because the interaction model is different.
+
+However, wording should still feel related:
+- use imperative verbs
+- keep hint phrases short
+- prefer consistent English labels across commands
+
+## Search behavior
+
+Filtering should feel consistent across selectors.
+
+Minimum contract:
+- case-insensitive
+- direct typing updates the filter immediately
+- `Backspace` and `Delete` modify the filter without entering a separate mode
+- when filter results shrink, cursor must stay within visible range
+
+Current `gion` matching may remain simple substring-based where already implemented.
+If `gion` later adopts the same fuzzy ordered-subsequence matching as `kra`, that
+should be treated as an enhancement, not a compatibility requirement for this spec.
+
+## Multi-select behavior
+
+For append-style multi-select in `gion`:
+
+- `Enter` adds the focused item to the selected set
+- after adding, the item may be removed from remaining candidates
+- the filter may be cleared after addition when that helps repeated entry
+- finishing requires at least one selected item
+- selected items must remain reviewable before the next stage
+
+Recommended UX rules:
+- keep the selected set visible without scrolling away from the input
+- keep finish instructions visible near the candidate list
+- do not require remembering hidden controls
+- avoid mixing selected and blocked states into the same visual block
+
+## Architecture guidance
+
+`gion` should still avoid per-command bespoke selectors.
+
+Preferred direction:
+- keep selector state machines in `internal/ui/prompt.go`
+- reuse shared rendering helpers for candidate rows and selected trees
+- keep `Frame` responsible for section ordering
+- keep command handlers responsible for supplying data, not formatting
+
+This does not require extracting a shared library with `kra`.
+That question should be revisited only after the interaction and visual contracts
+have stabilized independently in both projects.

--- a/docs/spec/ui/UI.md
+++ b/docs/spec/ui/UI.md
@@ -103,7 +103,13 @@ Steps
 - Help line: muted color, minimal content
 - Long selection lists should scroll so Inputs stay visible.
 
+Selector-specific interaction and visual rules are documented in
+[UI-SELECTOR.md](/Users/tasuku43/gionroot/workspaces/gion/gion/docs/spec/ui/UI-SELECTOR.md).
+
 ## Pickers
+
+Pickers in `gion` are flow-oriented by default. They should share visual language
+with `kra`, but are not required to copy `kra`'s in-list toggle model.
 
 ### Workspace picker line format
 When rendering workspace candidates (e.g. in `gion manifest rm`), use a compact single-line display:

--- a/internal/cli/giongo.go
+++ b/internal/cli/giongo.go
@@ -230,9 +230,6 @@ func buildGiongoWorkspaceChoices(ctx context.Context, entries []workspace.Entry)
 			} else if strings.TrimSpace(repoEntry.RepoSpec) != "" {
 				details = append(details, fmt.Sprintf("repo: %s", strings.TrimSpace(repoEntry.RepoSpec)))
 			}
-			if strings.TrimSpace(repoEntry.Branch) != "" {
-				details = append(details, fmt.Sprintf("branch: %s", repoEntry.Branch))
-			}
 			repoChoices = append(repoChoices, ui.PromptChoice{
 				Label:       label,
 				Value:       repoEntry.WorktreePath,

--- a/internal/cli/giongo_test.go
+++ b/internal/cli/giongo_test.go
@@ -2,11 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/tasuku43/gion/internal/domain/workspace"
 	"github.com/tasuku43/gion/internal/infra/shellaction"
 )
 
@@ -87,5 +90,43 @@ func TestFinalizeGiongoSelection_EmitsShellAction(t *testing.T) {
 	}
 	if string(data) != "builtin cd -- '/tmp/example'\n" {
 		t.Fatalf("action file = %q", string(data))
+	}
+}
+
+func TestBuildGiongoWorkspaceChoices_OmitsDuplicateBranchDetail(t *testing.T) {
+	root := t.TempDir()
+	wsPath := filepath.Join(root, "WS-1")
+	repoPath := filepath.Join(wsPath, "gion")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+		}
+	}
+	run("init", "-b", "feature/test")
+	run("remote", "add", "origin", "git@github.com:tasuku43/gion.git")
+
+	choices, err := buildGiongoWorkspaceChoices(context.Background(), []workspace.Entry{{
+		WorkspaceID:   "WS-1",
+		WorkspacePath: wsPath,
+	}})
+	if err != nil {
+		t.Fatalf("buildGiongoWorkspaceChoices() error: %v", err)
+	}
+	if len(choices) != 1 || len(choices[0].Repos) != 1 {
+		t.Fatalf("unexpected choices: %+v", choices)
+	}
+	repoChoice := choices[0].Repos[0]
+	if repoChoice.Label != "gion (branch: feature/test)" {
+		t.Fatalf("repo label = %q", repoChoice.Label)
+	}
+	if len(repoChoice.Details) != 1 || repoChoice.Details[0] != "repo: github.com/tasuku43/gion" {
+		t.Fatalf("repo details = %#v", repoChoice.Details)
 	}
 }

--- a/internal/ui/frame.go
+++ b/internal/ui/frame.go
@@ -180,6 +180,10 @@ func (cw *countingWriter) Write(p []byte) (int, error) {
 }
 
 func renderLine(r *Renderer, line frameLine) {
+	if line.kind == lineRaw && line.text == "" {
+		r.LineRaw("")
+		return
+	}
 	if strings.TrimSpace(line.text) == "" {
 		return
 	}
@@ -211,6 +215,10 @@ func copyRawLines(lines []string) []frameLine {
 	var out []frameLine
 	for _, line := range lines {
 		trimmed := strings.TrimRight(line, "\n")
+		if trimmed == "" {
+			out = append(out, frameLine{text: "", kind: lineRaw})
+			continue
+		}
 		if strings.TrimSpace(trimmed) == "" {
 			continue
 		}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -341,6 +341,95 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			}
+		case tea.KeySpace:
+			if m.stage == createStageMode {
+				if len(m.filtered) == 0 {
+					return m, nil
+				}
+				m.mode = m.filtered[m.cursor].Value
+				switch m.mode {
+				case "preset":
+					if m.tmplErr != nil {
+						m.err = m.tmplErr
+						return m, tea.Quit
+					}
+					m.stage = createStagePreset
+					m.presetModel = newInputsModel(m.title, m.presets, "", "", m.theme, m.useColor)
+				case "review":
+					if len(m.reviewRepos) == 0 {
+						m.err = fmt.Errorf("no GitHub repos found")
+						return m, tea.Quit
+					}
+					m.stage = createStageReviewRepo
+					m.reviewRepoModel = newChoiceSelectModel(m.title, "repo", m.reviewRepos, m.theme, m.useColor)
+				case "issue":
+					if len(m.issueRepos) == 0 {
+						m.err = fmt.Errorf("no repos with supported hosts found")
+						return m, tea.Quit
+					}
+					m.stage = createStageIssueRepo
+					m.issueRepoModel = newChoiceSelectModel(m.title, "repo", m.issueRepos, m.theme, m.useColor)
+				case "repo":
+					if m.repoErr != nil {
+						m.err = m.repoErr
+						return m, tea.Quit
+					}
+					if len(m.repoChoices) == 0 {
+						m.err = fmt.Errorf("no repos found")
+						return m, tea.Quit
+					}
+					m.stage = createStageRepoSelect
+					m.repoSelectModel = newChoiceSelectModel(m.title, "repo", m.repoChoices, m.theme, m.useColor)
+				default:
+					m.err = fmt.Errorf("unknown mode: %s", m.mode)
+					return m, tea.Quit
+				}
+				return m, nil
+			}
+		}
+		if m.stage == createStageMode && msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			m.mode = m.filtered[m.cursor].Value
+			switch m.mode {
+			case "preset":
+				if m.tmplErr != nil {
+					m.err = m.tmplErr
+					return m, tea.Quit
+				}
+				m.stage = createStagePreset
+				m.presetModel = newInputsModel(m.title, m.presets, "", "", m.theme, m.useColor)
+			case "review":
+				if len(m.reviewRepos) == 0 {
+					m.err = fmt.Errorf("no GitHub repos found")
+					return m, tea.Quit
+				}
+				m.stage = createStageReviewRepo
+				m.reviewRepoModel = newChoiceSelectModel(m.title, "repo", m.reviewRepos, m.theme, m.useColor)
+			case "issue":
+				if len(m.issueRepos) == 0 {
+					m.err = fmt.Errorf("no repos with supported hosts found")
+					return m, tea.Quit
+				}
+				m.stage = createStageIssueRepo
+				m.issueRepoModel = newChoiceSelectModel(m.title, "repo", m.issueRepos, m.theme, m.useColor)
+			case "repo":
+				if m.repoErr != nil {
+					m.err = m.repoErr
+					return m, tea.Quit
+				}
+				if len(m.repoChoices) == 0 {
+					m.err = fmt.Errorf("no repos found")
+					return m, tea.Quit
+				}
+				m.stage = createStageRepoSelect
+				m.repoSelectModel = newChoiceSelectModel(m.title, "repo", m.repoChoices, m.theme, m.useColor)
+			default:
+				m.err = fmt.Errorf("unknown mode: %s", m.mode)
+				return m, tea.Quit
+			}
+			return m, nil
 		}
 	}
 
@@ -593,11 +682,13 @@ func (m createFlowModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "mode")
 	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.modeInput.View()))
-	maxLines := listMaxLines(m.height, 1, 0)
+	assistLines := singleSelectAssistLines("select", m.modeInput.Value(), m.theme, m.useColor)
+	maxLines := listMaxLines(m.height, 1+len(assistLines), 0)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
+		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, nil, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
+	frame.AppendInputsRaw(assistLines...)
 	return frame.Render()
 }
 

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1429,6 +1429,25 @@ func (m choiceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.value = choice.Value
 			m.done = true
 			return m, tea.Quit
+		case tea.KeySpace:
+			if len(m.filtered) == 0 {
+				m.errorLine = "select a value"
+				return m, nil
+			}
+			choice := m.filtered[m.cursor]
+			m.value = choice.Value
+			m.done = true
+			return m, tea.Quit
+		}
+		if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				m.errorLine = "select a value"
+				return m, nil
+			}
+			choice := m.filtered[m.cursor]
+			m.value = choice.Value
+			m.done = true
+			return m, tea.Quit
 		}
 	}
 
@@ -1453,11 +1472,13 @@ func (m choiceSelectModel) View() string {
 	if m.errorLine != "" {
 		infoLines = 1
 	}
-	maxLines := listMaxLines(m.height, 1, infoLines)
+	assistLines := singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
+		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, nil, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
+	frame.AppendInputsRaw(assistLines...)
 
 	if m.errorLine != "" {
 		msg := m.errorLine
@@ -2433,6 +2454,19 @@ func (m workspaceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.workspaceID = m.filtered[m.cursor].ID
 			return m, tea.Quit
+		case tea.KeySpace:
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			m.workspaceID = m.filtered[m.cursor].ID
+			return m, tea.Quit
+		}
+		if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			m.workspaceID = m.filtered[m.cursor].ID
+			return m, tea.Quit
 		}
 	}
 
@@ -2457,11 +2491,13 @@ func (m workspaceSelectModel) View() string {
 		})
 		infoLines = 1 + len(blockedLines)
 	}
-	maxLines := listMaxLines(m.height, 1, infoLines)
+	assistLines := singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderWorkspaceChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
+		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, nil, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
+	frame.AppendInputsRaw(assistLines...)
 	if len(m.blocked) > 0 {
 		frame.SetInfo("blocked workspaces")
 		frame.AppendInfoRaw(blockedLines...)
@@ -3026,6 +3062,13 @@ func multiSelectAssistLines(selected []string, total int, action string, filterV
 	}
 }
 
+func singleSelectAssistLines(action string, filterValue string, theme Theme, useColor bool) []string {
+	return []string{
+		renderMultiSelectFilterLine(filterValue, theme, useColor),
+		renderSingleSelectFooterLine(action, theme, useColor),
+	}
+}
+
 func renderMultiSelectFilterLine(filterValue string, theme Theme, useColor bool) string {
 	body := strings.TrimSpace(filterValue)
 	line := fmt.Sprintf("%sfilter: %s", output.Indent, body)
@@ -3043,6 +3086,17 @@ func renderMultiSelectFooterLine(selectedCount int, total int, action string, th
 		action = "apply"
 	}
 	line := fmt.Sprintf("%sselected: %d/%d  ↑↓ move  space toggle  enter %s  type filter  esc cancel", output.Indent, selectedCount, total, action)
+	if useColor {
+		line = theme.Muted.Render(line)
+	}
+	return wrapRawLineToWidth(line, currentWrapWidth())[0]
+}
+
+func renderSingleSelectFooterLine(action string, theme Theme, useColor bool) string {
+	if strings.TrimSpace(action) == "" {
+		action = "select"
+	}
+	line := fmt.Sprintf("%s↑↓ move  space/enter %s  type filter  esc cancel", output.Indent, action)
 	if useColor {
 		line = theme.Muted.Render(line)
 	}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -496,13 +496,13 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.stage == createStageReviewPRs {
-		model, _ := m.reviewPRModel.Update(msg)
+		model, cmd := m.reviewPRModel.Update(msg)
 		m.reviewPRModel = model.(multiSelectModel)
 		if m.reviewPRModel.done {
 			m.reviewPRs = append([]string(nil), m.reviewPRModel.selectedValues...)
 			return m, tea.Quit
 		}
-		return m, nil
+		return m, cmd
 	}
 
 	if m.stage == createStageIssueRepo {
@@ -1362,7 +1362,7 @@ func (m presetRepoSelectModel) View() string {
 	assistLines := multiSelectAssistLines(m.selected, len(m.choices), "apply", m.repoInput.Value(), m.theme, m.useColor)
 	maxLines := listMaxLines(m.height, 2+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedChoiceSet(m.selected), m.useColor, m.theme)
+		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedChoiceSet(m.selected), false, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	frame.AppendInputsRaw(assistLines...)
@@ -1589,6 +1589,7 @@ type multiSelectModel struct {
 	err            error
 	errorLine      string
 	done           bool
+	confirming     bool
 
 	theme    Theme
 	useColor bool
@@ -1688,7 +1689,16 @@ func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		return m, nil
+	case singleSelectConfirmDoneMsg:
+		if m.confirming {
+			m.done = true
+			return m, tea.Quit
+		}
+		return m, nil
 	case tea.KeyMsg:
+		if m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -1715,8 +1725,9 @@ func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.errorLine = fmt.Sprintf("select at least one %s", m.label)
 				return m, nil
 			}
-			m.done = true
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		case tea.KeySpace:
 			if len(m.filtered) == 0 {
 				return m, nil
@@ -1770,13 +1781,18 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	if hasError {
 		infoLines++
 	}
-	assistLines := multiSelectAssistLines(model.selectedValues, len(model.choices), "apply", model.input.Value(), model.theme, model.useColor)
+	assistLines := []string(nil)
+	if !model.confirming {
+		assistLines = multiSelectAssistLines(model.selectedValues, len(model.choices), "apply", model.input.Value(), model.theme, model.useColor)
+	}
 	maxLines := listMaxLines(height, len(lines)+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoMultiSelectChoiceList(b, model.filtered, model.cursor, maxLines, selectedChoiceSet(model.selectedValues), model.useColor, model.theme)
+		renderRepoMultiSelectChoiceList(b, model.filtered, model.cursor, maxLines, selectedChoiceSet(model.selectedValues), model.confirming, model.useColor, model.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
-	frame.AppendInputsRaw(assistLines...)
+	if len(assistLines) > 0 {
+		frame.AppendInputsRaw(assistLines...)
+	}
 
 	if hasError {
 		msg := model.errorLine
@@ -2949,6 +2965,7 @@ type workspaceMultiSelectModel struct {
 	errorLine   string
 	canceled    bool
 	finalizing  bool
+	confirming  bool
 
 	theme    Theme
 	useColor bool
@@ -2987,7 +3004,16 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	switch msg := msg.(type) {
+	case singleSelectConfirmDoneMsg:
+		if m.confirming {
+			m.finalizing = true
+			return m, tea.Quit
+		}
+		return m, nil
 	case tea.KeyMsg:
+		if m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -2997,8 +3023,9 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.errorLine = "select at least one workspace"
 				return m, nil
 			}
-			m.finalizing = true
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		case tea.KeyUp:
 			if m.cursor > 0 {
 				m.cursor--
@@ -3014,8 +3041,9 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.errorLine = "select at least one workspace"
 				return m, nil
 			}
-			m.finalizing = true
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		case tea.KeySpace:
 			if len(m.filtered) == 0 {
 				return m, nil
@@ -3054,23 +3082,6 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m workspaceMultiSelectModel) View() string {
-	if m.finalizing {
-		frame := NewFrame(m.theme, m.useColor)
-		frame.NoBlankAfterInfo = true
-		label := promptLabel(m.theme, m.useColor, "workspace")
-		frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
-		selectedLines := collectLines(func(b *strings.Builder) {
-			renderSelectedWorkspaceTree(b, m.selected, m.useColor, m.theme)
-		})
-		if m.useColor {
-			frame.SetInfo(m.theme.Accent.Render("selected"))
-		} else {
-			frame.SetInfo("selected")
-		}
-		frame.AppendInfoRaw(selectedLines...)
-		return frame.Render()
-	}
-
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
 	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
@@ -3085,13 +3096,18 @@ func (m workspaceMultiSelectModel) View() string {
 		})
 		infoLines += 1 + len(blockedLines)
 	}
-	assistLines := multiSelectAssistLines(m.selectedIDs, len(m.workspaces), "apply", m.input.Value(), m.theme, m.useColor)
+	assistLines := []string(nil)
+	if !m.confirming {
+		assistLines = multiSelectAssistLines(m.selectedIDs, len(m.workspaces), "apply", m.input.Value(), m.theme, m.useColor)
+	}
 	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedWorkspaceSet(m.selectedIDs), m.useColor, m.theme)
+		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedWorkspaceSet(m.selectedIDs), m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
-	frame.AppendInputsRaw(assistLines...)
+	if len(assistLines) > 0 {
+		frame.AppendInputsRaw(assistLines...)
+	}
 
 	if m.errorLine != "" {
 		msg := m.errorLine
@@ -3303,7 +3319,7 @@ func renderRepoChoiceList(b *strings.Builder, items []PromptChoice, cursor int, 
 	}
 }
 
-func renderRepoMultiSelectChoiceList(b *strings.Builder, items []PromptChoice, cursor int, maxVisible int, selected map[string]bool, useColor bool, theme Theme) {
+func renderRepoMultiSelectChoiceList(b *strings.Builder, items []PromptChoice, cursor int, maxVisible int, selected map[string]bool, confirming bool, useColor bool, theme Theme) {
 	if maxVisible <= 0 {
 		return
 	}
@@ -3332,7 +3348,7 @@ func renderRepoMultiSelectChoiceList(b *strings.Builder, items []PromptChoice, c
 			selectMark = theme.Accent.Render(selectMark)
 		}
 		display := item.Label
-		if i == cursor && useColor {
+		if i == cursor && useColor && !confirming {
 			display = lipgloss.NewStyle().Bold(true).Render(display)
 		}
 		desc := strings.TrimSpace(item.Description)
@@ -3344,7 +3360,13 @@ func renderRepoMultiSelectChoiceList(b *strings.Builder, items []PromptChoice, c
 			}
 		}
 		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
-		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
+		wrapped := wrapRawLineToWidth(line, width)
+		if confirming && !selected[item.Value] && useColor {
+			for i := range wrapped {
+				wrapped[i] = theme.Muted.Render(ansi.Strip(wrapped[i]))
+			}
+		}
+		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapped})
 	}
 
 	if cursor < 0 || cursor >= len(groups) {
@@ -3887,7 +3909,7 @@ func renderWorkspaceChoiceList(b *strings.Builder, items []WorkspaceChoice, curs
 	}
 }
 
-func renderWorkspaceMultiSelectChoiceList(b *strings.Builder, items []WorkspaceChoice, cursor int, maxVisible int, selected map[string]bool, useColor bool, theme Theme) {
+func renderWorkspaceMultiSelectChoiceList(b *strings.Builder, items []WorkspaceChoice, cursor int, maxVisible int, selected map[string]bool, confirming bool, useColor bool, theme Theme) {
 	if maxVisible <= 0 {
 		return
 	}
@@ -3926,7 +3948,7 @@ func renderWorkspaceMultiSelectChoiceList(b *strings.Builder, items []WorkspaceC
 		if hasWarn {
 			warnTag = "[" + warnValue + "]"
 		}
-		if useColor && i == cursor {
+		if useColor && i == cursor && !confirming {
 			displayID = lipgloss.NewStyle().Bold(true).Render(displayID)
 		}
 		display := displayID
@@ -3950,7 +3972,13 @@ func renderWorkspaceMultiSelectChoiceList(b *strings.Builder, items []WorkspaceC
 			}
 		}
 		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
-		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
+		wrapped := wrapRawLineToWidth(line, width)
+		if confirming && !selected[item.ID] && useColor {
+			for i := range wrapped {
+				wrapped[i] = theme.Muted.Render(ansi.Strip(wrapped[i]))
+			}
+		}
+		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapped})
 	}
 
 	if cursor < 0 || cursor >= len(groups) {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -641,7 +641,7 @@ func (m createFlowModel) View() string {
 
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "mode")
-	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.modeInput.View()))
+	frame.SetInputsPrompt(renderPromptValueLine(label, m.pendingMode))
 	assistLines := []string(nil)
 	if !m.confirming {
 		assistLines = singleSelectAssistLines("select", m.modeInput.Value(), m.theme, m.useColor)
@@ -1535,7 +1535,7 @@ func (m choiceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m choiceSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
-	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
+	frame.SetInputsPrompt(renderPromptValueLine(label, m.value))
 
 	infoLines := 0
 	if m.errorLine != "" {
@@ -2587,7 +2587,7 @@ func (m workspaceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace id")
-	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
+	frame.SetInputsPrompt(renderPromptValueLine(label, m.workspaceID))
 	var blockedLines []string
 	infoLines := 0
 	if len(m.blocked) > 0 {
@@ -3186,6 +3186,14 @@ func renderMultiSelectFilterLine(filterValue string, theme Theme, useColor bool)
 		line = theme.Muted.Render(output.Indent+"filter: ") + body
 	}
 	return wrapRawLineToWidth(line, currentWrapWidth())[0]
+}
+
+func renderPromptValueLine(label, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Sprintf("%s:", label)
+	}
+	return fmt.Sprintf("%s: %s", label, value)
 }
 
 func renderMultiSelectFooterLine(selectedCount int, total int, action string, theme Theme, useColor bool) string {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1229,24 +1229,35 @@ func (m presetRepoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.errorLine = ""
 				return m, nil
 			}
-			value := strings.TrimSpace(m.repoInput.Value())
-			if value == "done" {
-				if len(m.selected) == 0 {
-					m.errorLine = "select at least one repo"
-					return m, nil
-				}
-				return m, tea.Quit
+			if len(m.selected) == 0 {
+				m.errorLine = "select at least one repo"
+				return m, nil
+			}
+			return m, tea.Quit
+		case tea.KeySpace:
+			if m.stage == stagePresetName {
+				return m, nil
 			}
 			if len(m.filtered) == 0 {
 				return m, nil
 			}
 			choice := m.filtered[m.cursor]
-			m.selected = append(m.selected, choice.Value)
-			m.choices = removeChoice(m.choices, choice.Value)
-			m.repoInput.SetValue("")
-			m.filtered = m.filterChoices()
-			if m.cursor >= len(m.filtered) {
-				m.cursor = max(0, len(m.filtered)-1)
+			m.selected = toggleSelectedValue(m.selected, choice.Value)
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+			}
+			m.addedNote = choice.Label
+			m.errorLine = ""
+			return m, nil
+		}
+		if m.stage == stageRepoSelect && msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			choice := m.filtered[m.cursor]
+			m.selected = toggleSelectedValue(m.selected, choice.Value)
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
 			}
 			m.addedNote = choice.Label
 			m.errorLine = ""
@@ -1288,26 +1299,17 @@ func (m presetRepoSelectModel) View() string {
 		fmt.Sprintf("%s: %s", labelRepo, repoInput),
 	)
 
-	selectedLines := collectLines(func(b *strings.Builder) {
-		renderSelectedRepoTree(b, m.selected, m.useColor, m.theme)
-	})
-	infoLines := 1 + len(selectedLines) + 1
+	infoLines := 0
 	if m.errorLine != "" {
 		infoLines++
 	}
-	// +1 for the inline "finish" help line appended under Inputs.
-	maxLines := listMaxLines(m.height, 3, infoLines)
+	assistLines := multiSelectAssistLines(m.selected, len(m.choices), "apply", m.repoInput.Value(), m.theme, m.useColor)
+	maxLines := listMaxLines(m.height, 2+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
+		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedChoiceSet(m.selected), m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
-
-	if m.useColor {
-		frame.SetInfo(m.theme.Accent.Render("selected"))
-	} else {
-		frame.SetInfo("selected")
-	}
-	frame.AppendInfoRaw(selectedLines...)
+	frame.AppendInputsRaw(assistLines...)
 
 	if m.errorLine != "" {
 		msg := m.errorLine
@@ -1317,10 +1319,6 @@ func (m presetRepoSelectModel) View() string {
 		frame.AppendInfoRaw(fmt.Sprintf("%s%s %s", output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), msg))
 	}
 
-	infoPrefix := mutedToken(m.theme, m.useColor, output.StepPrefix)
-	frame.AppendInputsRaw(
-		fmt.Sprintf("%s%s finish: Ctrl+D or type \"done\"", output.Indent, infoPrefix),
-	)
 	return frame.Render()
 }
 
@@ -1504,6 +1502,68 @@ type multiSelectModel struct {
 	height int
 }
 
+func selectedChoiceSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out[value] = true
+	}
+	return out
+}
+
+func toggleSelectedValue(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return append([]string(nil), values...)
+	}
+	for i, current := range values {
+		if current != value {
+			continue
+		}
+		out := append([]string(nil), values[:i]...)
+		out = append(out, values[i+1:]...)
+		return out
+	}
+	return append(append([]string(nil), values...), value)
+}
+
+func selectedChoicesFromValues(choices []PromptChoice, values []string) []PromptChoice {
+	selected := selectedChoiceSet(values)
+	out := make([]PromptChoice, 0, len(values))
+	for _, choice := range choices {
+		if selected[choice.Value] {
+			out = append(out, choice)
+		}
+	}
+	return out
+}
+
+func selectedWorkspaceSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out[value] = true
+	}
+	return out
+}
+
+func selectedWorkspacesFromIDs(workspaces []WorkspaceChoice, ids []string) []WorkspaceChoice {
+	selected := selectedWorkspaceSet(ids)
+	out := make([]WorkspaceChoice, 0, len(ids))
+	for _, workspace := range workspaces {
+		if selected[workspace.ID] {
+			out = append(out, workspace)
+		}
+	}
+	return out
+}
+
 func newMultiSelectModel(title, label string, choices []PromptChoice, theme Theme, useColor bool) multiSelectModel {
 	input := textinput.New()
 	input.Prompt = ""
@@ -1556,26 +1616,34 @@ func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case tea.KeyEnter:
-			value := strings.TrimSpace(m.input.Value())
-			if value == "done" {
-				if len(m.selected) == 0 {
-					m.errorLine = fmt.Sprintf("select at least one %s", m.label)
-					return m, nil
-				}
-				m.done = true
-				return m, tea.Quit
+			if len(m.selected) == 0 {
+				m.errorLine = fmt.Sprintf("select at least one %s", m.label)
+				return m, nil
 			}
+			m.done = true
+			return m, tea.Quit
+		case tea.KeySpace:
 			if len(m.filtered) == 0 {
 				return m, nil
 			}
 			choice := m.filtered[m.cursor]
-			m.selected = append(m.selected, choice)
-			m.selectedValues = append(m.selectedValues, choice.Value)
-			m.choices = removeChoice(m.choices, choice.Value)
-			m.input.SetValue("")
-			m.filtered = m.filterChoices()
-			if m.cursor >= len(m.filtered) {
-				m.cursor = max(0, len(m.filtered)-1)
+			m.selectedValues = toggleSelectedValue(m.selectedValues, choice.Value)
+			m.selected = selectedChoicesFromValues(m.choices, m.selectedValues)
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+			}
+			m.errorLine = ""
+			return m, nil
+		}
+		if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			choice := m.filtered[m.cursor]
+			m.selectedValues = toggleSelectedValue(m.selectedValues, choice.Value)
+			m.selected = selectedChoicesFromValues(m.choices, m.selectedValues)
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
 			}
 			m.errorLine = ""
 			return m, nil
@@ -1602,39 +1670,18 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	lines = append(lines, fmt.Sprintf("%s: %s", label, model.input.View()))
 	frame.SetInputsPrompt(lines...)
 
-	hasSelected := len(model.selected) > 0
 	hasError := model.errorLine != ""
-
-	var selectedLines []string
 	infoLines := 0
-	if hasSelected {
-		selectedLines = collectLines(func(b *strings.Builder) {
-			renderSelectedChoiceTree(b, model.selected, model.useColor, model.theme)
-		})
-		// "selected" header + selected lines
-		infoLines += 1 + len(selectedLines)
-	}
 	if hasError {
 		infoLines++
 	}
-	assistLines := multiSelectAssistLines(model.selectedValues, len(model.choices)+len(model.selected), "add", model.input.Value(), model.theme, model.useColor)
+	assistLines := multiSelectAssistLines(model.selectedValues, len(model.choices), "apply", model.input.Value(), model.theme, model.useColor)
 	maxLines := listMaxLines(height, len(lines)+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoChoiceList(b, model.filtered, model.cursor, maxLines, model.useColor, model.theme)
+		renderRepoMultiSelectChoiceList(b, model.filtered, model.cursor, maxLines, selectedChoiceSet(model.selectedValues), model.useColor, model.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	frame.AppendInputsRaw(assistLines...)
-
-	if hasSelected || hasError {
-		if hasSelected {
-			if model.useColor {
-				frame.SetInfo(model.theme.Accent.Render("selected"))
-			} else {
-				frame.SetInfo("selected")
-			}
-			frame.AppendInfoRaw(selectedLines...)
-		}
-	}
 
 	if hasError {
 		msg := model.errorLine
@@ -1943,29 +1990,48 @@ func (m issueBranchSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case tea.KeyEnter:
 			if m.stage == issueBranchStageSelect {
-				value := strings.TrimSpace(m.input.Value())
-				if value == "done" {
-					if len(m.selected) == 0 {
-						m.errorLine = fmt.Sprintf("select at least one %s", m.label)
-						return m, nil
-					}
-					m = m.startBranchInput()
+				if len(m.selected) == 0 {
+					m.errorLine = fmt.Sprintf("select at least one %s", m.label)
 					return m, nil
 				}
+				m = m.startBranchInput()
+				return m, nil
+			}
+		case tea.KeySpace:
+			if m.stage == issueBranchStageSelect {
 				if len(m.filtered) == 0 {
 					return m, nil
 				}
 				choice := m.filtered[m.cursor]
-				m.selected = append(m.selected, choice)
-				m.choices = removeChoice(m.choices, choice.Value)
-				m.input.SetValue("")
-				m.filtered = m.filterChoices()
-				if m.cursor >= len(m.filtered) {
-					m.cursor = max(0, len(m.filtered)-1)
+				values := make([]string, 0, len(m.selected))
+				for _, selected := range m.selected {
+					values = append(values, selected.Value)
+				}
+				values = toggleSelectedValue(values, choice.Value)
+				m.selected = selectedChoicesFromValues(m.choices, values)
+				if m.cursor < len(m.filtered)-1 {
+					m.cursor++
 				}
 				m.errorLine = ""
 				return m, nil
 			}
+		}
+		if m.stage == issueBranchStageSelect && msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			choice := m.filtered[m.cursor]
+			values := make([]string, 0, len(m.selected))
+			for _, selected := range m.selected {
+				values = append(values, selected.Value)
+			}
+			values = toggleSelectedValue(values, choice.Value)
+			m.selected = selectedChoicesFromValues(m.choices, values)
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+			}
+			m.errorLine = ""
+			return m, nil
 		}
 	}
 
@@ -2010,11 +2076,18 @@ func (m issueBranchSelectModel) View() string {
 		return m.branchModel.ViewWithHeader()
 	}
 	return renderMultiSelectFrame(multiSelectModel{
-		title:     m.title,
-		label:     m.label,
-		choices:   m.choices,
-		filtered:  m.filtered,
-		selected:  m.selected,
+		title:    m.title,
+		label:    m.label,
+		choices:  m.choices,
+		filtered: m.filtered,
+		selected: m.selected,
+		selectedValues: func() []string {
+			out := make([]string, 0, len(m.selected))
+			for _, selected := range m.selected {
+				out = append(out, selected.Value)
+			}
+			return out
+		}(),
 		cursor:    m.cursor,
 		errorLine: m.errorLine,
 		theme:     m.theme,
@@ -2807,26 +2880,34 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case tea.KeyEnter:
-			value := strings.TrimSpace(m.input.Value())
-			if value == "done" {
-				if len(m.selected) == 0 {
-					m.errorLine = "select at least one workspace"
-					return m, nil
-				}
-				m.finalizing = true
-				return m, tea.Quit
+			if len(m.selected) == 0 {
+				m.errorLine = "select at least one workspace"
+				return m, nil
 			}
+			m.finalizing = true
+			return m, tea.Quit
+		case tea.KeySpace:
 			if len(m.filtered) == 0 {
 				return m, nil
 			}
 			choice := m.filtered[m.cursor]
-			m.selected = append(m.selected, choice)
-			m.selectedIDs = append(m.selectedIDs, choice.ID)
-			m.workspaces = removeWorkspaceChoice(m.workspaces, choice.ID)
-			m.input.SetValue("")
-			m.filtered = m.filterWorkspaces()
-			if m.cursor >= len(m.filtered) {
-				m.cursor = max(0, len(m.filtered)-1)
+			m.selectedIDs = toggleSelectedValue(m.selectedIDs, choice.ID)
+			m.selected = selectedWorkspacesFromIDs(m.workspaces, m.selectedIDs)
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+			}
+			m.errorLine = ""
+			return m, nil
+		}
+		if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			choice := m.filtered[m.cursor]
+			m.selectedIDs = toggleSelectedValue(m.selectedIDs, choice.ID)
+			m.selected = selectedWorkspacesFromIDs(m.workspaces, m.selectedIDs)
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
 			}
 			m.errorLine = ""
 			return m, nil
@@ -2863,11 +2944,8 @@ func (m workspaceMultiSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
 	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
-	selectedLines := collectLines(func(b *strings.Builder) {
-		renderSelectedWorkspaceTree(b, m.selected, m.useColor, m.theme)
-	})
 	var blockedLines []string
-	infoLines := 1 + len(selectedLines) + 1
+	infoLines := 0
 	if m.errorLine != "" {
 		infoLines++
 	}
@@ -2877,20 +2955,13 @@ func (m workspaceMultiSelectModel) View() string {
 		})
 		infoLines += 1 + len(blockedLines)
 	}
-	assistLines := multiSelectAssistLines(m.selectedIDs, len(m.workspaces)+len(m.selected), "remove", m.input.Value(), m.theme, m.useColor)
+	assistLines := multiSelectAssistLines(m.selectedIDs, len(m.workspaces), "apply", m.input.Value(), m.theme, m.useColor)
 	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderWorkspaceChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
+		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedWorkspaceSet(m.selectedIDs), m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	frame.AppendInputsRaw(assistLines...)
-
-	if m.useColor {
-		frame.SetInfo(m.theme.Accent.Render("selected"))
-	} else {
-		frame.SetInfo("selected")
-	}
-	frame.AppendInfoRaw(selectedLines...)
 
 	if m.errorLine != "" {
 		msg := m.errorLine
@@ -2969,9 +3040,9 @@ func renderMultiSelectFooterLine(selectedCount int, total int, action string, th
 		total = selectedCount
 	}
 	if strings.TrimSpace(action) == "" {
-		action = "add"
+		action = "apply"
 	}
-	line := fmt.Sprintf("%sselected: %d/%d  ↑↓ move  enter %s  ctrl+d finish  esc cancel", output.Indent, selectedCount, total, action)
+	line := fmt.Sprintf("%sselected: %d/%d  ↑↓ move  space toggle  enter %s  type filter  esc cancel", output.Indent, selectedCount, total, action)
 	if useColor {
 		line = theme.Muted.Render(line)
 	}
@@ -3061,6 +3132,70 @@ func renderRepoChoiceList(b *strings.Builder, items []PromptChoice, cursor int, 
 			}
 		}
 		line := fmt.Sprintf("%s%s %s%s", output.Indent, focusMark, mutedToken(theme, useColor, connector), display)
+		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
+	}
+
+	if cursor < 0 || cursor >= len(groups) {
+		cursor = 0
+	}
+	if len(groups[cursor].lines) > maxVisible {
+		start, end := listWindow(len(groups[cursor].lines), 0, maxVisible)
+		for i := start; i < end; i++ {
+			b.WriteString(groups[cursor].lines[i])
+			b.WriteString("\n")
+		}
+		return
+	}
+	startGroup, endGroup := groupWindowByLineBudget(groups, cursor, maxVisible)
+	for gi := startGroup; gi < endGroup; gi++ {
+		for _, line := range groups[gi].lines {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+}
+
+func renderRepoMultiSelectChoiceList(b *strings.Builder, items []PromptChoice, cursor int, maxVisible int, selected map[string]bool, useColor bool, theme Theme) {
+	if maxVisible <= 0 {
+		return
+	}
+	if len(items) == 0 {
+		msg := "no matches"
+		if useColor {
+			msg = theme.Muted.Render(msg)
+		}
+		b.WriteString(fmt.Sprintf("%s%s%s\n", output.Indent+output.Indent, mutedToken(theme, useColor, output.TreeBranchLast), msg))
+		return
+	}
+
+	width := currentWrapWidth()
+	groups := make([]workspaceRepoChoiceGroup, 0, len(items))
+	for i := range items {
+		item := items[i]
+		focusMark := " "
+		if i == cursor {
+			focusMark = ">"
+		}
+		selectMark := "○"
+		if selected[item.Value] {
+			selectMark = "●"
+		}
+		if useColor && selected[item.Value] {
+			selectMark = theme.Accent.Render(selectMark)
+		}
+		display := item.Label
+		if i == cursor && useColor {
+			display = lipgloss.NewStyle().Bold(true).Render(display)
+		}
+		desc := strings.TrimSpace(item.Description)
+		if desc != "" {
+			if useColor {
+				display += theme.Muted.Render(" - " + desc)
+			} else {
+				display += " - " + desc
+			}
+		}
+		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
 		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
 	}
 
@@ -3510,6 +3645,92 @@ func renderWorkspaceChoiceList(b *strings.Builder, items []WorkspaceChoice, curs
 			}
 		}
 		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, connectorToken, display)
+		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
+	}
+
+	if cursor < 0 || cursor >= len(groups) {
+		cursor = 0
+	}
+	if len(groups[cursor].lines) > maxVisible {
+		start, end := listWindow(len(groups[cursor].lines), 0, maxVisible)
+		for i := start; i < end; i++ {
+			b.WriteString(groups[cursor].lines[i])
+			b.WriteString("\n")
+		}
+		return
+	}
+	startGroup, endGroup := groupWindowByLineBudget(groups, cursor, maxVisible)
+	for gi := startGroup; gi < endGroup; gi++ {
+		for _, line := range groups[gi].lines {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+}
+
+func renderWorkspaceMultiSelectChoiceList(b *strings.Builder, items []WorkspaceChoice, cursor int, maxVisible int, selected map[string]bool, useColor bool, theme Theme) {
+	if maxVisible <= 0 {
+		return
+	}
+	if len(items) == 0 {
+		msg := "no matches"
+		if useColor {
+			msg = theme.Muted.Render(msg)
+		}
+		b.WriteString(fmt.Sprintf("%s%s %s\n", output.Indent+output.Indent, mutedToken(theme, useColor, output.LogConnector), msg))
+		return
+	}
+
+	width := currentWrapWidth()
+	groups := make([]workspaceRepoChoiceGroup, 0, len(items))
+	for i := range items {
+		item := items[i]
+		focusMark := " "
+		if i == cursor {
+			focusMark = ">"
+		}
+		selectMark := "○"
+		if selected[item.ID] {
+			selectMark = "●"
+		}
+		if useColor && selected[item.ID] {
+			selectMark = theme.Accent.Render(selectMark)
+		}
+		displayID := item.ID
+		warnValue := shortWarningTag(item.Warning)
+		hasWarn := strings.TrimSpace(warnValue) != "" && strings.TrimSpace(strings.ToLower(warnValue)) != "clean"
+		warnStyle := theme.Warn
+		if item.WarningStrong {
+			warnStyle = theme.Error
+		}
+		warnTag := ""
+		if hasWarn {
+			warnTag = "[" + warnValue + "]"
+		}
+		if useColor && i == cursor {
+			displayID = lipgloss.NewStyle().Bold(true).Render(displayID)
+		}
+		display := displayID
+		if warnTag != "" {
+			tag := warnTag
+			if useColor {
+				if hasWarn {
+					tag = warnStyle.Render(warnTag)
+				} else {
+					tag = theme.Accent.Render(warnTag)
+				}
+			}
+			display += tag
+		}
+		desc := strings.TrimSpace(item.Description)
+		if desc != "" {
+			if useColor {
+				display += theme.Muted.Render(" - " + desc)
+			} else {
+				display += " - " + desc
+			}
+		}
+		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
 		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
 	}
 

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -3630,7 +3630,7 @@ func buildWorkspaceRepoChoiceGroups(items []WorkspaceChoice, cursor int, useColo
 		if !selected {
 			return baseIndent
 		}
-		return ">" + baseIndent[1:]
+		return output.Indent + "> "
 	}
 
 	cursorWorkspace := -1

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -649,12 +649,17 @@ func (m createFlowModel) View() string {
 	if !m.confirming {
 		assistLines = singleSelectAssistLines("select", m.modeInput.Value(), m.theme, m.useColor)
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines), 0)
+	extraAssistGap := 0
+	if len(assistLines) > 0 {
+		extraAssistGap = 1
+	}
+	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, 0)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.pendingMode, m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	if len(assistLines) > 0 {
+		frame.AppendInputsRaw("")
 		frame.AppendInputsRaw(assistLines...)
 	}
 	return frame.Render()
@@ -1558,12 +1563,17 @@ func (m choiceSelectModel) ViewWithHeader(headerLines ...string) string {
 	if !m.confirming {
 		assistLines = singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
+	extraAssistGap := 0
+	if len(assistLines) > 0 {
+		extraAssistGap = 1
+	}
+	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.value, m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	if len(assistLines) > 0 {
+		frame.AppendInputsRaw("")
 		frame.AppendInputsRaw(assistLines...)
 	}
 
@@ -1786,7 +1796,7 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	frame := NewFrame(model.theme, model.useColor)
 	lines := append([]string(nil), headerLines...)
 	label := promptLabel(model.theme, model.useColor, model.label)
-	lines = append(lines, fmt.Sprintf("%s: %s", label, model.input.View()))
+	lines = append(lines, renderPromptValueLine(label, ""))
 	frame.SetInputsPrompt(lines...)
 
 	hasError := model.errorLine != ""
@@ -1798,12 +1808,17 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	if !model.confirming {
 		assistLines = multiSelectAssistLines(model.selectedValues, len(model.choices), "apply", model.input.Value(), model.theme, model.useColor)
 	}
-	maxLines := listMaxLines(height, len(lines)+len(assistLines), infoLines)
+	extraAssistGap := 0
+	if len(assistLines) > 0 {
+		extraAssistGap = 1
+	}
+	maxLines := listMaxLines(height, len(lines)+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoMultiSelectChoiceList(b, model.filtered, model.cursor, maxLines, selectedChoiceSet(model.selectedValues), model.confirming, model.useColor, model.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	if len(assistLines) > 0 {
+		frame.AppendInputsRaw("")
 		frame.AppendInputsRaw(assistLines...)
 	}
 
@@ -2619,12 +2634,17 @@ func (m workspaceSelectModel) ViewWithHeader(headerLines ...string) string {
 	if !m.confirming {
 		assistLines = singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
+	extraAssistGap := 0
+	if len(assistLines) > 0 {
+		extraAssistGap = 1
+	}
+	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.workspaceID, m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	if len(assistLines) > 0 {
+		frame.AppendInputsRaw("")
 		frame.AppendInputsRaw(assistLines...)
 	}
 	if len(m.blocked) > 0 {
@@ -2748,12 +2768,15 @@ func (m workspaceRepoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceRepoSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
-	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
-	maxLines := listMaxLines(m.height, 1, 0)
+	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
+	assistLines := singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	maxLines := listMaxLines(m.height, 1+len(assistLines)+1, 0)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceRepoChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
+	frame.AppendInputsRaw("")
+	frame.AppendInputsRaw(assistLines...)
 	return frame.Render()
 }
 
@@ -3103,7 +3126,7 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceMultiSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
-	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
+	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
 	var blockedLines []string
 	infoLines := 0
 	if m.errorLine != "" {
@@ -3119,12 +3142,17 @@ func (m workspaceMultiSelectModel) View() string {
 	if !m.confirming {
 		assistLines = multiSelectAssistLines(m.selectedIDs, len(m.workspaces), "apply", m.input.Value(), m.theme, m.useColor)
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
+	extraAssistGap := 0
+	if len(assistLines) > 0 {
+		extraAssistGap = 1
+	}
+	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedWorkspaceSet(m.selectedIDs), m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
 	if len(assistLines) > 0 {
+		frame.AppendInputsRaw("")
 		frame.AppendInputsRaw(assistLines...)
 	}
 

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -490,6 +490,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.reviewPRModel = newMultiSelectModel(m.title, "pull request", choices, m.theme, m.useColor)
 			m.stage = createStageReviewPRs
+			return m, nil
 		}
 		return m, cmd
 	}
@@ -523,6 +524,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.issueIssueModel = newIssueBranchSelectModel(m.title, "issue", choices, m.validateBranch, m.theme, m.useColor)
 			m.stage = createStageIssueIssues
+			return m, nil
 		}
 		return m, cmd
 	}
@@ -548,6 +550,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.presetModel = newInputsModelWithLabel(m.title, nil, m.repoSelected, m.defaultWorkspaceID, "repo", m.validateWorkspaceID, m.theme, m.useColor)
 			m.stage = createStageRepoWorkspace
+			return m, nil
 		}
 		return m, cmd
 	}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -14,6 +15,16 @@ import (
 )
 
 var ErrPromptCanceled = errors.New("prompt canceled")
+
+const singleSelectConfirmDelay = 200 * time.Millisecond
+
+type singleSelectConfirmDoneMsg struct{}
+
+func singleSelectConfirmCmd() tea.Cmd {
+	return tea.Tick(singleSelectConfirmDelay, func(time.Time) tea.Msg {
+		return singleSelectConfirmDoneMsg{}
+	})
+}
 
 type PromptChoice struct {
 	Label       string
@@ -98,10 +109,12 @@ type createFlowModel struct {
 	presets []string
 	tmplErr error
 
-	modeInput textinput.Model
-	filtered  []PromptChoice
-	cursor    int
-	err       error
+	modeInput   textinput.Model
+	filtered    []PromptChoice
+	cursor      int
+	err         error
+	confirming  bool
+	pendingMode string
 
 	presetModel        inputsModel
 	presetRepos        []string
@@ -189,6 +202,57 @@ func newCreateFlowModel(title string, presets []string, tmplErr error, repoChoic
 
 func (m createFlowModel) Init() tea.Cmd {
 	return textinput.Blink
+}
+
+func (m *createFlowModel) confirmSelectedMode(mode string) (tea.Model, tea.Cmd) {
+	m.pendingMode = strings.TrimSpace(mode)
+	m.confirming = true
+	m.modeInput.Blur()
+	return m, singleSelectConfirmCmd()
+}
+
+func (m *createFlowModel) applySelectedMode() (tea.Model, tea.Cmd) {
+	m.confirming = false
+	m.mode = m.pendingMode
+	m.pendingMode = ""
+	switch m.mode {
+	case "preset":
+		if m.tmplErr != nil {
+			m.err = m.tmplErr
+			return m, tea.Quit
+		}
+		m.stage = createStagePreset
+		m.presetModel = newInputsModel(m.title, m.presets, "", "", m.theme, m.useColor)
+	case "review":
+		if len(m.reviewRepos) == 0 {
+			m.err = fmt.Errorf("no GitHub repos found")
+			return m, tea.Quit
+		}
+		m.stage = createStageReviewRepo
+		m.reviewRepoModel = newChoiceSelectModel(m.title, "repo", m.reviewRepos, m.theme, m.useColor)
+	case "issue":
+		if len(m.issueRepos) == 0 {
+			m.err = fmt.Errorf("no repos with supported hosts found")
+			return m, tea.Quit
+		}
+		m.stage = createStageIssueRepo
+		m.issueRepoModel = newChoiceSelectModel(m.title, "repo", m.issueRepos, m.theme, m.useColor)
+	case "repo":
+		if m.repoErr != nil {
+			m.err = m.repoErr
+			return m, tea.Quit
+		}
+		if len(m.repoChoices) == 0 {
+			m.err = fmt.Errorf("no repos found")
+			return m, tea.Quit
+		}
+		m.stage = createStageRepoSelect
+		m.repoSelectModel = newChoiceSelectModel(m.title, "repo", m.repoChoices, m.theme, m.useColor)
+	default:
+		m.err = fmt.Errorf("unknown mode: %s", m.mode)
+		return m, tea.Quit
+	}
+	return m, nil
 }
 
 func (m *createFlowModel) startMode(mode, presetName string) {
@@ -281,7 +345,15 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	switch msg := msg.(type) {
+	case singleSelectConfirmDoneMsg:
+		if m.stage == createStageMode && m.confirming {
+			return m.applySelectedMode()
+		}
+		return m, nil
 	case tea.KeyMsg:
+		if m.stage == createStageMode && m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -301,135 +373,21 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if len(m.filtered) == 0 {
 					return m, nil
 				}
-				m.mode = m.filtered[m.cursor].Value
-				switch m.mode {
-				case "preset":
-					if m.tmplErr != nil {
-						m.err = m.tmplErr
-						return m, tea.Quit
-					}
-					m.stage = createStagePreset
-					m.presetModel = newInputsModel(m.title, m.presets, "", "", m.theme, m.useColor)
-				case "review":
-					if len(m.reviewRepos) == 0 {
-						m.err = fmt.Errorf("no GitHub repos found")
-						return m, tea.Quit
-					}
-					m.stage = createStageReviewRepo
-					m.reviewRepoModel = newChoiceSelectModel(m.title, "repo", m.reviewRepos, m.theme, m.useColor)
-				case "issue":
-					if len(m.issueRepos) == 0 {
-						m.err = fmt.Errorf("no repos with supported hosts found")
-						return m, tea.Quit
-					}
-					m.stage = createStageIssueRepo
-					m.issueRepoModel = newChoiceSelectModel(m.title, "repo", m.issueRepos, m.theme, m.useColor)
-				case "repo":
-					if m.repoErr != nil {
-						m.err = m.repoErr
-						return m, tea.Quit
-					}
-					if len(m.repoChoices) == 0 {
-						m.err = fmt.Errorf("no repos found")
-						return m, tea.Quit
-					}
-					m.stage = createStageRepoSelect
-					m.repoSelectModel = newChoiceSelectModel(m.title, "repo", m.repoChoices, m.theme, m.useColor)
-				default:
-					m.err = fmt.Errorf("unknown mode: %s", m.mode)
-					return m, tea.Quit
-				}
-				return m, nil
+				return m.confirmSelectedMode(m.filtered[m.cursor].Value)
 			}
 		case tea.KeySpace:
 			if m.stage == createStageMode {
 				if len(m.filtered) == 0 {
 					return m, nil
 				}
-				m.mode = m.filtered[m.cursor].Value
-				switch m.mode {
-				case "preset":
-					if m.tmplErr != nil {
-						m.err = m.tmplErr
-						return m, tea.Quit
-					}
-					m.stage = createStagePreset
-					m.presetModel = newInputsModel(m.title, m.presets, "", "", m.theme, m.useColor)
-				case "review":
-					if len(m.reviewRepos) == 0 {
-						m.err = fmt.Errorf("no GitHub repos found")
-						return m, tea.Quit
-					}
-					m.stage = createStageReviewRepo
-					m.reviewRepoModel = newChoiceSelectModel(m.title, "repo", m.reviewRepos, m.theme, m.useColor)
-				case "issue":
-					if len(m.issueRepos) == 0 {
-						m.err = fmt.Errorf("no repos with supported hosts found")
-						return m, tea.Quit
-					}
-					m.stage = createStageIssueRepo
-					m.issueRepoModel = newChoiceSelectModel(m.title, "repo", m.issueRepos, m.theme, m.useColor)
-				case "repo":
-					if m.repoErr != nil {
-						m.err = m.repoErr
-						return m, tea.Quit
-					}
-					if len(m.repoChoices) == 0 {
-						m.err = fmt.Errorf("no repos found")
-						return m, tea.Quit
-					}
-					m.stage = createStageRepoSelect
-					m.repoSelectModel = newChoiceSelectModel(m.title, "repo", m.repoChoices, m.theme, m.useColor)
-				default:
-					m.err = fmt.Errorf("unknown mode: %s", m.mode)
-					return m, tea.Quit
-				}
-				return m, nil
+				return m.confirmSelectedMode(m.filtered[m.cursor].Value)
 			}
 		}
 		if m.stage == createStageMode && msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
 			if len(m.filtered) == 0 {
 				return m, nil
 			}
-			m.mode = m.filtered[m.cursor].Value
-			switch m.mode {
-			case "preset":
-				if m.tmplErr != nil {
-					m.err = m.tmplErr
-					return m, tea.Quit
-				}
-				m.stage = createStagePreset
-				m.presetModel = newInputsModel(m.title, m.presets, "", "", m.theme, m.useColor)
-			case "review":
-				if len(m.reviewRepos) == 0 {
-					m.err = fmt.Errorf("no GitHub repos found")
-					return m, tea.Quit
-				}
-				m.stage = createStageReviewRepo
-				m.reviewRepoModel = newChoiceSelectModel(m.title, "repo", m.reviewRepos, m.theme, m.useColor)
-			case "issue":
-				if len(m.issueRepos) == 0 {
-					m.err = fmt.Errorf("no repos with supported hosts found")
-					return m, tea.Quit
-				}
-				m.stage = createStageIssueRepo
-				m.issueRepoModel = newChoiceSelectModel(m.title, "repo", m.issueRepos, m.theme, m.useColor)
-			case "repo":
-				if m.repoErr != nil {
-					m.err = m.repoErr
-					return m, tea.Quit
-				}
-				if len(m.repoChoices) == 0 {
-					m.err = fmt.Errorf("no repos found")
-					return m, tea.Quit
-				}
-				m.stage = createStageRepoSelect
-				m.repoSelectModel = newChoiceSelectModel(m.title, "repo", m.repoChoices, m.theme, m.useColor)
-			default:
-				m.err = fmt.Errorf("unknown mode: %s", m.mode)
-				return m, tea.Quit
-			}
-			return m, nil
+			return m.confirmSelectedMode(m.filtered[m.cursor].Value)
 		}
 	}
 
@@ -682,13 +640,18 @@ func (m createFlowModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "mode")
 	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.modeInput.View()))
-	assistLines := singleSelectAssistLines("select", m.modeInput.Value(), m.theme, m.useColor)
+	assistLines := []string(nil)
+	if !m.confirming {
+		assistLines = singleSelectAssistLines("select", m.modeInput.Value(), m.theme, m.useColor)
+	}
 	maxLines := listMaxLines(m.height, 1+len(assistLines), 0)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, nil, m.useColor, m.theme)
+		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.pendingMode, m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
-	frame.AppendInputsRaw(assistLines...)
+	if len(assistLines) > 0 {
+		frame.AppendInputsRaw(assistLines...)
+	}
 	return frame.Render()
 }
 
@@ -1460,9 +1423,10 @@ type choiceSelectModel struct {
 	errorLine string
 	done      bool
 
-	theme    Theme
-	useColor bool
-	input    textinput.Model
+	theme      Theme
+	useColor   bool
+	input      textinput.Model
+	confirming bool
 
 	height int
 }
@@ -1496,7 +1460,16 @@ func (m choiceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		return m, nil
+	case singleSelectConfirmDoneMsg:
+		if m.confirming {
+			m.done = true
+			return m, tea.Quit
+		}
+		return m, nil
 	case tea.KeyMsg:
+		if m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -1518,8 +1491,9 @@ func (m choiceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			choice := m.filtered[m.cursor]
 			m.value = choice.Value
-			m.done = true
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		case tea.KeySpace:
 			if len(m.filtered) == 0 {
 				m.errorLine = "select a value"
@@ -1527,8 +1501,9 @@ func (m choiceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			choice := m.filtered[m.cursor]
 			m.value = choice.Value
-			m.done = true
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		}
 		if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
 			if len(m.filtered) == 0 {
@@ -1537,8 +1512,9 @@ func (m choiceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			choice := m.filtered[m.cursor]
 			m.value = choice.Value
-			m.done = true
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		}
 	}
 
@@ -1563,13 +1539,18 @@ func (m choiceSelectModel) View() string {
 	if m.errorLine != "" {
 		infoLines = 1
 	}
-	assistLines := singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	assistLines := []string(nil)
+	if !m.confirming {
+		assistLines = singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	}
 	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, nil, m.useColor, m.theme)
+		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.value, m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
-	frame.AppendInputsRaw(assistLines...)
+	if len(assistLines) > 0 {
+		frame.AppendInputsRaw(assistLines...)
+	}
 
 	if m.errorLine != "" {
 		msg := m.errorLine
@@ -2487,6 +2468,7 @@ type workspaceSelectModel struct {
 	err      error
 
 	workspaceID string
+	confirming  bool
 
 	height int
 }
@@ -2524,7 +2506,15 @@ func (m workspaceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		return m, nil
+	case singleSelectConfirmDoneMsg:
+		if m.confirming {
+			return m, tea.Quit
+		}
+		return m, nil
 	case tea.KeyMsg:
+		if m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -2544,20 +2534,26 @@ func (m workspaceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.workspaceID = m.filtered[m.cursor].ID
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		case tea.KeySpace:
 			if len(m.filtered) == 0 {
 				return m, nil
 			}
 			m.workspaceID = m.filtered[m.cursor].ID
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		}
 		if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
 			if len(m.filtered) == 0 {
 				return m, nil
 			}
 			m.workspaceID = m.filtered[m.cursor].ID
-			return m, tea.Quit
+			m.confirming = true
+			m.input.Blur()
+			return m, singleSelectConfirmCmd()
 		}
 	}
 
@@ -2582,13 +2578,18 @@ func (m workspaceSelectModel) View() string {
 		})
 		infoLines = 1 + len(blockedLines)
 	}
-	assistLines := singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	assistLines := []string(nil)
+	if !m.confirming {
+		assistLines = singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	}
 	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, nil, m.useColor, m.theme)
+		renderWorkspaceSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.workspaceID, m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
-	frame.AppendInputsRaw(assistLines...)
+	if len(assistLines) > 0 {
+		frame.AppendInputsRaw(assistLines...)
+	}
 	if len(m.blocked) > 0 {
 		frame.SetInfo("blocked workspaces")
 		frame.AppendInfoRaw(blockedLines...)
@@ -3364,6 +3365,77 @@ func renderRepoMultiSelectChoiceList(b *strings.Builder, items []PromptChoice, c
 	}
 }
 
+func renderRepoSingleSelectChoiceList(b *strings.Builder, items []PromptChoice, cursor int, maxVisible int, selectedValue string, confirming bool, useColor bool, theme Theme) {
+	if maxVisible <= 0 {
+		return
+	}
+	if len(items) == 0 {
+		msg := "no matches"
+		if useColor {
+			msg = theme.Muted.Render(msg)
+		}
+		b.WriteString(fmt.Sprintf("%s%s%s\n", output.Indent+output.Indent, mutedToken(theme, useColor, output.TreeBranchLast), msg))
+		return
+	}
+
+	width := currentWrapWidth()
+	groups := make([]workspaceRepoChoiceGroup, 0, len(items))
+	for i := range items {
+		item := items[i]
+		focusMark := " "
+		if i == cursor {
+			focusMark = ">"
+		}
+		selected := item.Value == selectedValue
+		selectMark := "○"
+		if selected {
+			selectMark = "●"
+		}
+		if useColor && selected {
+			selectMark = theme.Accent.Render(selectMark)
+		}
+		display := item.Label
+		if i == cursor && useColor && !confirming {
+			display = lipgloss.NewStyle().Bold(true).Render(display)
+		}
+		desc := strings.TrimSpace(item.Description)
+		if desc != "" {
+			if useColor {
+				display += theme.Muted.Render(" - " + desc)
+			} else {
+				display += " - " + desc
+			}
+		}
+		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
+		wrapped := wrapRawLineToWidth(line, width)
+		if confirming && !selected && useColor {
+			for i := range wrapped {
+				wrapped[i] = theme.Muted.Render(ansi.Strip(wrapped[i]))
+			}
+		}
+		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapped})
+	}
+
+	if cursor < 0 || cursor >= len(groups) {
+		cursor = 0
+	}
+	if len(groups[cursor].lines) > maxVisible {
+		start, end := listWindow(len(groups[cursor].lines), 0, maxVisible)
+		for i := start; i < end; i++ {
+			b.WriteString(groups[cursor].lines[i])
+			b.WriteString("\n")
+		}
+		return
+	}
+	startGroup, endGroup := groupWindowByLineBudget(groups, cursor, maxVisible)
+	for gi := startGroup; gi < endGroup; gi++ {
+		for _, line := range groups[gi].lines {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+}
+
 func renderSelectedRepoList(b *strings.Builder, items []string, useColor bool, theme Theme) {
 	if len(items) == 0 {
 		msg := "none"
@@ -3877,6 +3949,99 @@ func renderWorkspaceMultiSelectChoiceList(b *strings.Builder, items []WorkspaceC
 		}
 		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
 		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
+	}
+
+	if cursor < 0 || cursor >= len(groups) {
+		cursor = 0
+	}
+	if len(groups[cursor].lines) > maxVisible {
+		start, end := listWindow(len(groups[cursor].lines), 0, maxVisible)
+		for i := start; i < end; i++ {
+			b.WriteString(groups[cursor].lines[i])
+			b.WriteString("\n")
+		}
+		return
+	}
+	startGroup, endGroup := groupWindowByLineBudget(groups, cursor, maxVisible)
+	for gi := startGroup; gi < endGroup; gi++ {
+		for _, line := range groups[gi].lines {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+}
+
+func renderWorkspaceSingleSelectChoiceList(b *strings.Builder, items []WorkspaceChoice, cursor int, maxVisible int, selectedID string, confirming bool, useColor bool, theme Theme) {
+	if maxVisible <= 0 {
+		return
+	}
+	if len(items) == 0 {
+		msg := "no matches"
+		if useColor {
+			msg = theme.Muted.Render(msg)
+		}
+		b.WriteString(fmt.Sprintf("%s%s %s\n", output.Indent+output.Indent, mutedToken(theme, useColor, output.LogConnector), msg))
+		return
+	}
+
+	width := currentWrapWidth()
+	groups := make([]workspaceRepoChoiceGroup, 0, len(items))
+	for i := range items {
+		item := items[i]
+		focusMark := " "
+		if i == cursor {
+			focusMark = ">"
+		}
+		selected := item.ID == selectedID
+		selectMark := "○"
+		if selected {
+			selectMark = "●"
+		}
+		if useColor && selected {
+			selectMark = theme.Accent.Render(selectMark)
+		}
+		displayID := item.ID
+		warnValue := shortWarningTag(item.Warning)
+		hasWarn := strings.TrimSpace(warnValue) != "" && strings.TrimSpace(strings.ToLower(warnValue)) != "clean"
+		warnStyle := theme.Warn
+		if item.WarningStrong {
+			warnStyle = theme.Error
+		}
+		warnTag := ""
+		if hasWarn {
+			warnTag = "[" + warnValue + "]"
+		}
+		if useColor && i == cursor && !confirming {
+			displayID = lipgloss.NewStyle().Bold(true).Render(displayID)
+		}
+		display := displayID
+		if warnTag != "" {
+			tag := warnTag
+			if useColor {
+				if hasWarn {
+					tag = warnStyle.Render(warnTag)
+				} else {
+					tag = theme.Accent.Render(warnTag)
+				}
+			}
+			display += tag
+		}
+		desc := strings.TrimSpace(item.Description)
+		if desc != "" {
+			if useColor {
+				display += theme.Muted.Render(" - " + desc)
+			} else {
+				display += " - " + desc
+			}
+		}
+		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
+		wrapped := wrapRawLineToWidth(line, width)
+		if confirming && !selected && useColor {
+			for i := range wrapped {
+				wrapped[i] = theme.Muted.Render(ansi.Strip(wrapped[i]))
+			}
+		}
+		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapped})
 	}
 
 	if cursor < 0 || cursor >= len(groups) {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1617,12 +1617,13 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	if hasError {
 		infoLines++
 	}
-	// +1 for the inline "finish" help line appended under Inputs.
-	maxLines := listMaxLines(height, len(lines)+1, infoLines)
+	assistLines := multiSelectAssistLines(model.selectedValues, len(model.choices)+len(model.selected), "add", model.input.Value(), model.theme, model.useColor)
+	maxLines := listMaxLines(height, len(lines)+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoChoiceList(b, model.filtered, model.cursor, maxLines, model.useColor, model.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
+	frame.AppendInputsRaw(assistLines...)
 
 	if hasSelected || hasError {
 		if hasSelected {
@@ -1643,10 +1644,6 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 		frame.AppendInfoRaw(fmt.Sprintf("%s%s %s", output.Indent, mutedToken(model.theme, model.useColor, output.LogConnector), msg))
 	}
 
-	infoPrefix := mutedToken(model.theme, model.useColor, output.StepPrefix)
-	frame.AppendInputsRaw(
-		fmt.Sprintf("%s%s finish: Ctrl+D or type \"done\"", output.Indent, infoPrefix),
-	)
 	return frame.Render()
 }
 
@@ -2880,12 +2877,13 @@ func (m workspaceMultiSelectModel) View() string {
 		})
 		infoLines += 1 + len(blockedLines)
 	}
-	// +1 for the inline "finish" help line appended under Inputs.
-	maxLines := listMaxLines(m.height, 2, infoLines)
+	assistLines := multiSelectAssistLines(m.selectedIDs, len(m.workspaces)+len(m.selected), "remove", m.input.Value(), m.theme, m.useColor)
+	maxLines := listMaxLines(m.height, 1+len(assistLines), infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
+	frame.AppendInputsRaw(assistLines...)
 
 	if m.useColor {
 		frame.SetInfo(m.theme.Accent.Render("selected"))
@@ -2901,9 +2899,6 @@ func (m workspaceMultiSelectModel) View() string {
 		}
 		frame.AppendInfoRaw(fmt.Sprintf("%s%s %s", output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), msg))
 	}
-
-	infoPrefix := mutedToken(m.theme, m.useColor, output.StepPrefix)
-	frame.AppendInputsRaw(fmt.Sprintf("%s%s finish: Ctrl+D or type \"done\"", output.Indent, infoPrefix))
 
 	if len(blockedLines) > 0 {
 		frame.AppendInfo("blocked workspaces")
@@ -2951,6 +2946,36 @@ func listWindow(total int, cursor int, maxVisible int) (int, int) {
 		start = total - maxVisible
 	}
 	return start, start + maxVisible
+}
+
+func multiSelectAssistLines(selected []string, total int, action string, filterValue string, theme Theme, useColor bool) []string {
+	return []string{
+		renderMultiSelectFilterLine(filterValue, theme, useColor),
+		renderMultiSelectFooterLine(len(selected), total, action, theme, useColor),
+	}
+}
+
+func renderMultiSelectFilterLine(filterValue string, theme Theme, useColor bool) string {
+	body := strings.TrimSpace(filterValue)
+	line := fmt.Sprintf("%sfilter: %s", output.Indent, body)
+	if useColor {
+		line = theme.Muted.Render(output.Indent+"filter: ") + body
+	}
+	return wrapRawLineToWidth(line, currentWrapWidth())[0]
+}
+
+func renderMultiSelectFooterLine(selectedCount int, total int, action string, theme Theme, useColor bool) string {
+	if total < selectedCount {
+		total = selectedCount
+	}
+	if strings.TrimSpace(action) == "" {
+		action = "add"
+	}
+	line := fmt.Sprintf("%sselected: %d/%d  ↑↓ move  enter %s  ctrl+d finish  esc cancel", output.Indent, selectedCount, total, action)
+	if useColor {
+		line = theme.Muted.Render(line)
+	}
+	return wrapRawLineToWidth(line, currentWrapWidth())[0]
 }
 
 func renderChoiceList(b *strings.Builder, items []string, cursor int, maxVisible int, useColor bool, theme Theme) {
@@ -3015,6 +3040,10 @@ func renderRepoChoiceList(b *strings.Builder, items []PromptChoice, cursor int, 
 	groups := make([]workspaceRepoChoiceGroup, 0, len(items))
 	for i := range items {
 		item := items[i]
+		focusMark := " "
+		if i == cursor {
+			focusMark = ">"
+		}
 		connector := output.TreeBranchMid
 		if i == len(items)-1 {
 			connector = output.TreeBranchLast
@@ -3031,7 +3060,7 @@ func renderRepoChoiceList(b *strings.Builder, items []PromptChoice, cursor int, 
 				display += " - " + desc
 			}
 		}
-		line := fmt.Sprintf("%s%s%s", output.Indent+output.Indent, mutedToken(theme, useColor, connector), display)
+		line := fmt.Sprintf("%s%s %s%s", output.Indent, focusMark, mutedToken(theme, useColor, connector), display)
 		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
 	}
 
@@ -3441,6 +3470,10 @@ func renderWorkspaceChoiceList(b *strings.Builder, items []WorkspaceChoice, curs
 	groups := make([]workspaceRepoChoiceGroup, 0, len(items))
 	for i := range items {
 		item := items[i]
+		focusMark := " "
+		if i == cursor {
+			focusMark = ">"
+		}
 		connectorToken := mutedToken(theme, useColor, output.LogConnector)
 		displayID := item.ID
 		warnValue := shortWarningTag(item.Warning)
@@ -3476,7 +3509,7 @@ func renderWorkspaceChoiceList(b *strings.Builder, items []WorkspaceChoice, curs
 				display += " - " + desc
 			}
 		}
-		line := fmt.Sprintf("%s%s %s", output.Indent+output.Indent, connectorToken, display)
+		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, connectorToken, display)
 		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
 	}
 

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -3627,7 +3627,7 @@ func buildWorkspaceRepoChoiceGroups(items []WorkspaceChoice, cursor int, useColo
 
 	baseIndent := output.Indent + output.Indent
 	selectIndent := func(selected bool) string {
-		if !selected || useColor {
+		if !selected {
 			return baseIndent
 		}
 		return ">" + baseIndent[1:]

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -349,7 +349,6 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.stage == createStageMode && m.confirming {
 			return m.applySelectedMode()
 		}
-		return m, nil
 	case tea.KeyMsg:
 		if m.stage == createStageMode && m.confirming {
 			return m, nil
@@ -473,7 +472,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.stage == createStageReviewRepo {
-		model, _ := m.reviewRepoModel.Update(msg)
+		model, cmd := m.reviewRepoModel.Update(msg)
 		m.reviewRepoModel = model.(choiceSelectModel)
 		if m.reviewRepoModel.done {
 			m.reviewRepo = m.reviewRepoModel.value
@@ -492,7 +491,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.reviewPRModel = newMultiSelectModel(m.title, "pull request", choices, m.theme, m.useColor)
 			m.stage = createStageReviewPRs
 		}
-		return m, nil
+		return m, cmd
 	}
 
 	if m.stage == createStageReviewPRs {
@@ -506,7 +505,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.stage == createStageIssueRepo {
-		model, _ := m.issueRepoModel.Update(msg)
+		model, cmd := m.issueRepoModel.Update(msg)
 		m.issueRepoModel = model.(choiceSelectModel)
 		if m.issueRepoModel.done {
 			m.issueRepo = m.issueRepoModel.value
@@ -525,7 +524,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.issueIssueModel = newIssueBranchSelectModel(m.title, "issue", choices, m.validateBranch, m.theme, m.useColor)
 			m.stage = createStageIssueIssues
 		}
-		return m, nil
+		return m, cmd
 	}
 
 	if m.stage == createStageIssueIssues {
@@ -539,7 +538,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.stage == createStageRepoSelect {
-		model, _ := m.repoSelectModel.Update(msg)
+		model, cmd := m.repoSelectModel.Update(msg)
 		m.repoSelectModel = model.(choiceSelectModel)
 		if m.repoSelectModel.done {
 			m.repoSelected = m.repoSelectModel.value
@@ -550,7 +549,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.presetModel = newInputsModelWithLabel(m.title, nil, m.repoSelected, m.defaultWorkspaceID, "repo", m.validateWorkspaceID, m.theme, m.useColor)
 			m.stage = createStageRepoWorkspace
 		}
-		return m, nil
+		return m, cmd
 	}
 
 	if m.stage == createStageRepoWorkspace {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -575,8 +575,10 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m createFlowModel) View() string {
+	modeLabel := promptLabel(m.theme, m.useColor, "mode")
+	modeLine := renderPromptValueLine(modeLabel, m.mode)
 	if m.stage == createStagePreset {
-		return m.presetModel.View()
+		return m.presetModel.ViewWithHeader(modeLine)
 	}
 	if m.stage == createStagePresetDesc {
 		frame := NewFrame(m.theme, m.useColor)
@@ -584,6 +586,7 @@ func (m createFlowModel) View() string {
 		labelWorkspace := promptLabel(m.theme, m.useColor, "workspace id")
 		labelDesc := promptLabel(m.theme, m.useColor, "description")
 		frame.SetInputsPrompt(
+			modeLine,
 			fmt.Sprintf("%s: %s", labelSelection, m.selectionValue()),
 			fmt.Sprintf("%s: %s", labelWorkspace, m.workspaceID()),
 			fmt.Sprintf("%s: %s", labelDesc, m.descInput.View()),
@@ -595,6 +598,7 @@ func (m createFlowModel) View() string {
 		labelWorkspace := promptLabel(m.theme, m.useColor, "workspace id")
 		labelDesc := promptLabel(m.theme, m.useColor, "description")
 		lines := []string{
+			modeLine,
 			fmt.Sprintf("%s: %s", labelSelection, m.selectionValue()),
 			fmt.Sprintf("%s: %s", labelWorkspace, m.workspaceID()),
 		}
@@ -604,19 +608,19 @@ func (m createFlowModel) View() string {
 		return m.branchModel.ViewWithHeader(lines...)
 	}
 	if m.stage == createStageReviewRepo {
-		return m.reviewRepoModel.View()
+		return m.reviewRepoModel.ViewWithHeader(modeLine)
 	}
 	if m.stage == createStageReviewPRs {
 		labelRepo := promptLabel(m.theme, m.useColor, "repo")
-		return renderMultiSelectFrame(m.reviewPRModel, m.reviewPRModel.height, fmt.Sprintf("%s: %s", labelRepo, m.reviewRepo))
+		return renderMultiSelectFrame(m.reviewPRModel, m.reviewPRModel.height, modeLine, fmt.Sprintf("%s: %s", labelRepo, m.reviewRepo))
 	}
 	if m.stage == createStageIssueRepo {
-		return m.issueRepoModel.View()
+		return m.issueRepoModel.ViewWithHeader(modeLine)
 	}
 	if m.stage == createStageIssueIssues {
 		labelRepo := promptLabel(m.theme, m.useColor, "repo")
 		if m.issueIssueModel.stage == issueBranchStageEdit {
-			return m.issueIssueModel.branchModel.ViewWithHeader(fmt.Sprintf("%s: %s", labelRepo, m.issueRepo))
+			return m.issueIssueModel.branchModel.ViewWithHeader(modeLine, fmt.Sprintf("%s: %s", labelRepo, m.issueRepo))
 		}
 		return renderMultiSelectFrame(multiSelectModel{
 			title:     m.issueIssueModel.title,
@@ -630,18 +634,17 @@ func (m createFlowModel) View() string {
 			useColor:  m.issueIssueModel.useColor,
 			input:     m.issueIssueModel.input,
 			height:    m.issueIssueModel.height,
-		}, m.issueIssueModel.height, fmt.Sprintf("%s: %s", labelRepo, m.issueRepo))
+		}, m.issueIssueModel.height, modeLine, fmt.Sprintf("%s: %s", labelRepo, m.issueRepo))
 	}
 	if m.stage == createStageRepoSelect {
-		return m.repoSelectModel.View()
+		return m.repoSelectModel.ViewWithHeader(modeLine)
 	}
 	if m.stage == createStageRepoWorkspace {
-		return m.presetModel.View()
+		return m.presetModel.ViewWithHeader(modeLine)
 	}
 
 	frame := NewFrame(m.theme, m.useColor)
-	label := promptLabel(m.theme, m.useColor, "mode")
-	frame.SetInputsPrompt(renderPromptValueLine(label, m.pendingMode))
+	frame.SetInputsPrompt(renderPromptValueLine(modeLabel, m.pendingMode))
 	assistLines := []string(nil)
 	if !m.confirming {
 		assistLines = singleSelectAssistLines("select", m.modeInput.Value(), m.theme, m.useColor)
@@ -821,13 +824,17 @@ func (m inputsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m inputsModel) View() string {
+	return m.ViewWithHeader()
+}
+
+func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := strings.TrimSpace(m.label)
 	if label == "" {
 		label = "preset"
 	}
 	labelPreset := promptLabel(m.theme, m.useColor, label)
-	var promptLines []string
+	promptLines := append([]string(nil), headerLines...)
 	if m.stage == stagePreset {
 		promptLines = append(promptLines, fmt.Sprintf("%s: %s", labelPreset, m.search.View()))
 	} else {
@@ -1533,9 +1540,15 @@ func (m choiceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m choiceSelectModel) View() string {
+	return m.ViewWithHeader()
+}
+
+func (m choiceSelectModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
-	frame.SetInputsPrompt(renderPromptValueLine(label, m.value))
+	promptLines := append([]string(nil), headerLines...)
+	promptLines = append(promptLines, renderPromptValueLine(label, m.value))
+	frame.SetInputsPrompt(promptLines...)
 
 	infoLines := 0
 	if m.errorLine != "" {
@@ -2585,9 +2598,15 @@ func (m workspaceSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m workspaceSelectModel) View() string {
+	return m.ViewWithHeader()
+}
+
+func (m workspaceSelectModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace id")
-	frame.SetInputsPrompt(renderPromptValueLine(label, m.workspaceID))
+	promptLines := append([]string(nil), headerLines...)
+	promptLines = append(promptLines, renderPromptValueLine(label, m.workspaceID))
+	frame.SetInputsPrompt(promptLines...)
 	var blockedLines []string
 	infoLines := 0
 	if len(m.blocked) > 0 {

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -167,7 +167,7 @@ func TestRepoMultiSelectRows_ShowSelectionMarker(t *testing.T) {
 	renderRepoMultiSelectChoiceList(&b, []PromptChoice{
 		{Label: "example/repo-a", Value: "a"},
 		{Label: "example/repo-b", Value: "b"},
-	}, 0, 10, map[string]bool{"b": true}, false, DefaultTheme())
+	}, 0, 10, map[string]bool{"b": true}, false, false, DefaultTheme())
 
 	out := b.String()
 	if !strings.Contains(out, "○ example/repo-a") || !strings.Contains(out, "● example/repo-b") {
@@ -180,7 +180,7 @@ func TestWorkspaceMultiSelectRows_ShowSelectionMarker(t *testing.T) {
 	renderWorkspaceMultiSelectChoiceList(&b, []WorkspaceChoice{
 		{ID: "WS-1", Description: "first"},
 		{ID: "WS-2", Description: "second"},
-	}, 0, 10, map[string]bool{"WS-2": true}, false, DefaultTheme())
+	}, 0, 10, map[string]bool{"WS-2": true}, false, false, DefaultTheme())
 
 	out := b.String()
 	if !strings.Contains(out, "○ WS-1 - first") || !strings.Contains(out, "● WS-2 - second") {
@@ -206,6 +206,54 @@ func TestMultiSelectModel_SpaceTogglesSelection(t *testing.T) {
 	next = updated.(multiSelectModel)
 	if len(next.selectedValues) != 0 {
 		t.Fatalf("expected second toggle to clear selection, got: %+v", next.selectedValues)
+	}
+}
+
+func TestMultiSelectView_HidesAssistLinesWhileConfirming(t *testing.T) {
+	model := newMultiSelectModel("title", "pull request", []PromptChoice{
+		{Label: "#1", Value: "1"},
+		{Label: "#2", Value: "2"},
+	}, DefaultTheme(), false)
+	model.selectedValues = []string{"1"}
+	model.selected = []PromptChoice{{Label: "#1", Value: "1"}}
+	model.confirming = true
+	model.input.SetValue("s")
+
+	view := model.View()
+	if strings.Contains(view, "filter: s") {
+		t.Fatalf("expected filter assist line to be hidden while confirming, got: %q", view)
+	}
+	if strings.Contains(view, "selected: 1/2") {
+		t.Fatalf("expected footer assist line to be hidden while confirming, got: %q", view)
+	}
+	if !strings.Contains(view, "● #1") || !strings.Contains(view, "○ #2") {
+		t.Fatalf("expected selection markers to remain visible while confirming, got: %q", view)
+	}
+}
+
+func TestMultiSelectModel_EnterStartsConfirmTimer(t *testing.T) {
+	model := newMultiSelectModel("title", "pull request", []PromptChoice{
+		{Label: "#1", Value: "1"},
+	}, DefaultTheme(), false)
+	model.selectedValues = []string{"1"}
+	model.selected = []PromptChoice{{Label: "#1", Value: "1"}}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(multiSelectModel)
+	if !next.confirming {
+		t.Fatalf("expected multi-select to enter confirming state")
+	}
+	if cmd == nil {
+		t.Fatalf("expected confirm timer command")
+	}
+
+	updated, cmd = next.Update(singleSelectConfirmDoneMsg{})
+	next = updated.(multiSelectModel)
+	if !next.done {
+		t.Fatalf("expected confirm completion to finish multi-select")
+	}
+	if cmd == nil {
+		t.Fatalf("expected quit command after confirm completion")
 	}
 }
 
@@ -397,6 +445,46 @@ func TestCreateFlowReviewRepo_ConfirmAdvancesToPRSelection(t *testing.T) {
 	}
 	if cmd != nil {
 		t.Fatalf("expected no quit command after advancing to PR selection")
+	}
+}
+
+func TestCreateFlowReviewPRs_EnterStartsConfirmTimer(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"review",
+		"",
+	)
+	model.stage = createStageReviewPRs
+	model.reviewRepo = "chatwork/terraforms"
+	model.reviewPRModel = newMultiSelectModel("gion manifest add", "pull request", []PromptChoice{
+		{Label: "#1", Value: "1"},
+	}, DefaultTheme(), false)
+	model.reviewPRModel.selectedValues = []string{"1"}
+	model.reviewPRModel.selected = []PromptChoice{{Label: "#1", Value: "1"}}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(createFlowModel)
+	if !next.reviewPRModel.confirming {
+		t.Fatalf("expected review PR selector to enter confirming state")
+	}
+	if cmd == nil {
+		t.Fatalf("expected confirm timer command to propagate from review PR selector")
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -265,6 +265,9 @@ func TestChoiceSelectView_ShowsSingleSelectAssistLines(t *testing.T) {
 	model.input.SetValue("repo")
 
 	view := model.View()
+	if strings.Contains(view, "• repo: repo") {
+		t.Fatalf("active filter should not be echoed in header line, got: %q", view)
+	}
 	if !strings.Contains(view, "filter: repo") {
 		t.Fatalf("expected filter assist line, got: %q", view)
 	}
@@ -284,6 +287,9 @@ func TestWorkspaceSelectView_ShowsSingleSelectAssistLines(t *testing.T) {
 	model.input.SetValue("WS")
 
 	view := model.View()
+	if strings.Contains(view, "• workspace id: WS") {
+		t.Fatalf("active filter should not be echoed in header line, got: %q", view)
+	}
 	if !strings.Contains(view, "filter: WS") {
 		t.Fatalf("expected filter assist line, got: %q", view)
 	}
@@ -579,6 +585,9 @@ func TestCreateFlowModeView_HidesAssistAndMutesOthersWhileConfirming(t *testing.
 	model.cursor = 1
 
 	view := model.View()
+	if !strings.Contains(view, "• mode: issue") {
+		t.Fatalf("confirming mode view should show selected mode in header, got: %q", view)
+	}
 	if strings.Contains(view, "filter:") || strings.Contains(view, "space/enter") {
 		t.Fatalf("confirming mode view should hide assist lines, got: %q", view)
 	}
@@ -587,6 +596,23 @@ func TestCreateFlowModeView_HidesAssistAndMutesOthersWhileConfirming(t *testing.
 	}
 	if !strings.Contains(view, "○ repo - 1 repo only") {
 		t.Fatalf("confirming mode view should keep unselected rows visible, got: %q", view)
+	}
+}
+
+func TestChoiceSelectView_ShowsSelectedValueInHeaderWhileConfirming(t *testing.T) {
+	model := newChoiceSelectModel("title", "repo", []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
+		{Label: "example/repo-b", Value: "b"},
+	}, DefaultTheme(), false)
+	model.value = "b"
+	model.confirming = true
+
+	view := model.View()
+	if !strings.Contains(view, "• repo: b") {
+		t.Fatalf("confirming single-select should show selected value in header, got: %q", view)
+	}
+	if strings.Contains(view, "filter:") {
+		t.Fatalf("confirming single-select should hide filter line, got: %q", view)
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -275,6 +275,74 @@ func TestWorkspaceSelectModel_SpaceSelectsCurrent(t *testing.T) {
 	}
 }
 
+func TestCreateFlowModeView_ShowsSingleSelectAssistLines(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"",
+		"",
+	)
+	model.modeInput.SetValue("s")
+	model.filtered = model.filterModes()
+
+	view := model.View()
+	if !strings.Contains(view, "filter: s") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "space/enter select") {
+		t.Fatalf("expected single-select hint line, got: %q", view)
+	}
+	if !strings.Contains(view, "○ issue") {
+		t.Fatalf("expected single-select row markers, got: %q", view)
+	}
+}
+
+func TestCreateFlowMode_SpaceSelectsCurrentMode(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		[]PromptChoice{{Label: "repo-1", Value: "repo-1"}},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"",
+		"",
+	)
+	model.cursor = 2
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next := updated.(createFlowModel)
+	if next.stage != createStageReviewRepo {
+		t.Fatalf("expected space to move to review repo stage, got %v", next.stage)
+	}
+}
+
 func TestStableLayout_TruncatesLinesWithDots(t *testing.T) {
 	setWrapWidth(20)
 	defer setWrapWidth(0)

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/tasuku43/gion/internal/infra/output"
 )
@@ -89,6 +90,7 @@ func TestMultiSelectView_DoesNotExceedHeight(t *testing.T) {
 
 func TestMultiSelectView_ShowsAssistLines(t *testing.T) {
 	model := newMultiSelectModel("title", "repo", []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
 		{Label: "example/repo-b", Value: "b"},
 	}, DefaultTheme(), false)
 	model.selectedValues = []string{"a"}
@@ -102,13 +104,17 @@ func TestMultiSelectView_ShowsAssistLines(t *testing.T) {
 	if !strings.Contains(view, "selected: 1/2") {
 		t.Fatalf("expected selected summary line, got: %q", view)
 	}
-	if !strings.Contains(view, "enter add") {
+	if !strings.Contains(view, "space toggle") {
+		t.Fatalf("expected toggle hint line, got: %q", view)
+	}
+	if !strings.Contains(view, "enter apply") {
 		t.Fatalf("expected action hint line, got: %q", view)
 	}
 }
 
 func TestWorkspaceMultiSelectView_ShowsAssistLines(t *testing.T) {
 	model := newWorkspaceMultiSelectModel("gion manifest rm", []WorkspaceChoice{
+		{ID: "WS-1", Description: "first"},
 		{ID: "WS-2", Description: "second"},
 	}, nil, DefaultTheme(), false)
 	model.selectedIDs = []string{"WS-1"}
@@ -122,8 +128,11 @@ func TestWorkspaceMultiSelectView_ShowsAssistLines(t *testing.T) {
 	if !strings.Contains(view, "selected: 1/2") {
 		t.Fatalf("expected selected summary line, got: %q", view)
 	}
-	if !strings.Contains(view, "enter remove") {
-		t.Fatalf("expected remove action hint line, got: %q", view)
+	if !strings.Contains(view, "space toggle") {
+		t.Fatalf("expected toggle hint line, got: %q", view)
+	}
+	if !strings.Contains(view, "enter apply") {
+		t.Fatalf("expected apply action hint line, got: %q", view)
 	}
 }
 
@@ -150,6 +159,53 @@ func TestWorkspaceMultiSelectCandidateRows_ShowFocusMarker(t *testing.T) {
 	out := b.String()
 	if !strings.Contains(out, "> └─ WS-1 - first") {
 		t.Fatalf("expected focused workspace row marker, got: %q", out)
+	}
+}
+
+func TestRepoMultiSelectRows_ShowSelectionMarker(t *testing.T) {
+	var b strings.Builder
+	renderRepoMultiSelectChoiceList(&b, []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
+		{Label: "example/repo-b", Value: "b"},
+	}, 0, 10, map[string]bool{"b": true}, false, DefaultTheme())
+
+	out := b.String()
+	if !strings.Contains(out, "○ example/repo-a") || !strings.Contains(out, "● example/repo-b") {
+		t.Fatalf("expected selection markers, got: %q", out)
+	}
+}
+
+func TestWorkspaceMultiSelectRows_ShowSelectionMarker(t *testing.T) {
+	var b strings.Builder
+	renderWorkspaceMultiSelectChoiceList(&b, []WorkspaceChoice{
+		{ID: "WS-1", Description: "first"},
+		{ID: "WS-2", Description: "second"},
+	}, 0, 10, map[string]bool{"WS-2": true}, false, DefaultTheme())
+
+	out := b.String()
+	if !strings.Contains(out, "○ WS-1 - first") || !strings.Contains(out, "● WS-2 - second") {
+		t.Fatalf("expected selection markers, got: %q", out)
+	}
+}
+
+func TestMultiSelectModel_SpaceTogglesSelection(t *testing.T) {
+	model := newMultiSelectModel("title", "repo", []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
+		{Label: "example/repo-b", Value: "b"},
+	}, DefaultTheme(), false)
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next := updated.(multiSelectModel)
+	if len(next.selectedValues) != 1 || next.selectedValues[0] != "a" {
+		t.Fatalf("expected first toggle to select a, got: %+v", next.selectedValues)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyUp})
+	next = updated.(multiSelectModel)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next = updated.(multiSelectModel)
+	if len(next.selectedValues) != 0 {
+		t.Fatalf("expected second toggle to clear selection, got: %+v", next.selectedValues)
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -87,6 +87,72 @@ func TestMultiSelectView_DoesNotExceedHeight(t *testing.T) {
 	}
 }
 
+func TestMultiSelectView_ShowsAssistLines(t *testing.T) {
+	model := newMultiSelectModel("title", "repo", []PromptChoice{
+		{Label: "example/repo-b", Value: "b"},
+	}, DefaultTheme(), false)
+	model.selectedValues = []string{"a"}
+	model.selected = []PromptChoice{{Label: "example/repo-a", Value: "a"}}
+	model.input.SetValue("repo")
+
+	view := model.View()
+	if !strings.Contains(view, "filter: repo") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "selected: 1/2") {
+		t.Fatalf("expected selected summary line, got: %q", view)
+	}
+	if !strings.Contains(view, "enter add") {
+		t.Fatalf("expected action hint line, got: %q", view)
+	}
+}
+
+func TestWorkspaceMultiSelectView_ShowsAssistLines(t *testing.T) {
+	model := newWorkspaceMultiSelectModel("gion manifest rm", []WorkspaceChoice{
+		{ID: "WS-2", Description: "second"},
+	}, nil, DefaultTheme(), false)
+	model.selectedIDs = []string{"WS-1"}
+	model.selected = []WorkspaceChoice{{ID: "WS-1", Description: "first"}}
+	model.input.SetValue("WS")
+
+	view := model.View()
+	if !strings.Contains(view, "filter: WS") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "selected: 1/2") {
+		t.Fatalf("expected selected summary line, got: %q", view)
+	}
+	if !strings.Contains(view, "enter remove") {
+		t.Fatalf("expected remove action hint line, got: %q", view)
+	}
+}
+
+func TestMultiSelectCandidateRows_ShowFocusMarker(t *testing.T) {
+	var b strings.Builder
+	renderRepoChoiceList(&b, []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
+		{Label: "example/repo-b", Value: "b"},
+	}, 1, 10, false, DefaultTheme())
+
+	out := b.String()
+	if !strings.Contains(out, "> └─ example/repo-b") {
+		t.Fatalf("expected focused repo row marker, got: %q", out)
+	}
+}
+
+func TestWorkspaceMultiSelectCandidateRows_ShowFocusMarker(t *testing.T) {
+	var b strings.Builder
+	renderWorkspaceChoiceList(&b, []WorkspaceChoice{
+		{ID: "WS-1", Description: "first"},
+		{ID: "WS-2", Description: "second"},
+	}, 0, 10, false, DefaultTheme())
+
+	out := b.String()
+	if !strings.Contains(out, "> └─ WS-1 - first") {
+		t.Fatalf("expected focused workspace row marker, got: %q", out)
+	}
+}
+
 func TestStableLayout_TruncatesLinesWithDots(t *testing.T) {
 	setWrapWidth(20)
 	defer setWrapWidth(0)

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -98,6 +98,9 @@ func TestMultiSelectView_ShowsAssistLines(t *testing.T) {
 	model.input.SetValue("repo")
 
 	view := model.View()
+	if strings.Contains(view, "• repo: repo") {
+		t.Fatalf("active filter should not be echoed in multi-select header, got: %q", view)
+	}
 	if !strings.Contains(view, "filter: repo") {
 		t.Fatalf("expected filter assist line, got: %q", view)
 	}
@@ -109,6 +112,9 @@ func TestMultiSelectView_ShowsAssistLines(t *testing.T) {
 	}
 	if !strings.Contains(view, "enter apply") {
 		t.Fatalf("expected action hint line, got: %q", view)
+	}
+	if !strings.Contains(view, "\n\n  filter: repo") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
 	}
 }
 
@@ -122,6 +128,9 @@ func TestWorkspaceMultiSelectView_ShowsAssistLines(t *testing.T) {
 	model.input.SetValue("WS")
 
 	view := model.View()
+	if strings.Contains(view, "• workspace: WS") {
+		t.Fatalf("active filter should not be echoed in workspace multi-select header, got: %q", view)
+	}
 	if !strings.Contains(view, "filter: WS") {
 		t.Fatalf("expected filter assist line, got: %q", view)
 	}
@@ -133,6 +142,9 @@ func TestWorkspaceMultiSelectView_ShowsAssistLines(t *testing.T) {
 	}
 	if !strings.Contains(view, "enter apply") {
 		t.Fatalf("expected apply action hint line, got: %q", view)
+	}
+	if !strings.Contains(view, "\n\n  filter: WS") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
 	}
 }
 
@@ -277,6 +289,9 @@ func TestChoiceSelectView_ShowsSingleSelectAssistLines(t *testing.T) {
 	if strings.Contains(view, "selected:") {
 		t.Fatalf("single-select should not show selected summary, got: %q", view)
 	}
+	if !strings.Contains(view, "\n\n  filter: repo") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
+	}
 }
 
 func TestWorkspaceSelectView_ShowsSingleSelectAssistLines(t *testing.T) {
@@ -298,6 +313,9 @@ func TestWorkspaceSelectView_ShowsSingleSelectAssistLines(t *testing.T) {
 	}
 	if strings.Contains(view, "selected:") {
 		t.Fatalf("single-select should not show selected summary, got: %q", view)
+	}
+	if !strings.Contains(view, "\n\n  filter: WS") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
 	}
 }
 
@@ -372,6 +390,9 @@ func TestCreateFlowModeView_ShowsSingleSelectAssistLines(t *testing.T) {
 	}
 	if !strings.Contains(view, "○ issue") {
 		t.Fatalf("expected single-select row markers, got: %q", view)
+	}
+	if !strings.Contains(view, "\n\n  filter: s") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -256,8 +256,14 @@ func TestChoiceSelectModel_SpaceSelectsCurrent(t *testing.T) {
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
 	next := updated.(choiceSelectModel)
-	if next.value != "b" || !next.done {
-		t.Fatalf("expected space to select b, got value=%q done=%v", next.value, next.done)
+	if next.value != "b" || !next.confirming || next.done {
+		t.Fatalf("expected space to enter confirming for b, got value=%q confirming=%v done=%v", next.value, next.confirming, next.done)
+	}
+
+	updated, _ = next.Update(singleSelectConfirmDoneMsg{})
+	next = updated.(choiceSelectModel)
+	if !next.done {
+		t.Fatalf("expected confirm message to complete selection")
 	}
 }
 
@@ -270,8 +276,8 @@ func TestWorkspaceSelectModel_SpaceSelectsCurrent(t *testing.T) {
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
 	next := updated.(workspaceSelectModel)
-	if next.workspaceID != "WS-2" {
-		t.Fatalf("expected space to select WS-2, got %q", next.workspaceID)
+	if next.workspaceID != "WS-2" || !next.confirming {
+		t.Fatalf("expected space to enter confirming for WS-2, got workspaceID=%q confirming=%v", next.workspaceID, next.confirming)
 	}
 }
 
@@ -337,9 +343,75 @@ func TestCreateFlowMode_SpaceSelectsCurrentMode(t *testing.T) {
 	model.cursor = 2
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
-	next := updated.(createFlowModel)
+	next := updated.(*createFlowModel)
+	if !next.confirming || next.pendingMode != "review" {
+		t.Fatalf("expected space to enter confirming review mode, got confirming=%v pendingMode=%q", next.confirming, next.pendingMode)
+	}
+
+	updated, _ = next.Update(singleSelectConfirmDoneMsg{})
+	next = updated.(*createFlowModel)
 	if next.stage != createStageReviewRepo {
-		t.Fatalf("expected space to move to review repo stage, got %v", next.stage)
+		t.Fatalf("expected confirm message to move to review repo stage, got %v", next.stage)
+	}
+}
+
+func TestChoiceSelectView_HidesAssistAndMutesOthersWhileConfirming(t *testing.T) {
+	model := newChoiceSelectModel("title", "repo", []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
+		{Label: "example/repo-b", Value: "b"},
+	}, DefaultTheme(), true)
+	model.value = "b"
+	model.confirming = true
+	model.cursor = 1
+
+	view := model.View()
+	if strings.Contains(view, "filter:") || strings.Contains(view, "space/enter") {
+		t.Fatalf("confirming view should hide assist lines, got: %q", view)
+	}
+	if !strings.Contains(view, "●") {
+		t.Fatalf("confirming view should show selected marker, got: %q", view)
+	}
+	if !strings.Contains(view, "○ example/repo-a") {
+		t.Fatalf("confirming view should keep unselected rows visible, got: %q", view)
+	}
+}
+
+func TestCreateFlowModeView_HidesAssistAndMutesOthersWhileConfirming(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		true,
+		"",
+		"",
+	)
+	model.confirming = true
+	model.pendingMode = "issue"
+	model.filtered = model.filterModes()
+	model.cursor = 1
+
+	view := model.View()
+	if strings.Contains(view, "filter:") || strings.Contains(view, "space/enter") {
+		t.Fatalf("confirming mode view should hide assist lines, got: %q", view)
+	}
+	if !strings.Contains(view, "●") {
+		t.Fatalf("confirming mode view should show selected marker, got: %q", view)
+	}
+	if !strings.Contains(view, "○ repo - 1 repo only") {
+		t.Fatalf("confirming mode view should keep unselected rows visible, got: %q", view)
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -361,6 +361,9 @@ func TestCreateFlowModeView_ShowsSingleSelectAssistLines(t *testing.T) {
 	model.filtered = model.filterModes()
 
 	view := model.View()
+	if !strings.Contains(view, "• mode:") {
+		t.Fatalf("expected mode header line, got: %q", view)
+	}
 	if !strings.Contains(view, "filter: s") {
 		t.Fatalf("expected filter assist line, got: %q", view)
 	}
@@ -369,6 +372,103 @@ func TestCreateFlowModeView_ShowsSingleSelectAssistLines(t *testing.T) {
 	}
 	if !strings.Contains(view, "○ issue") {
 		t.Fatalf("expected single-select row markers, got: %q", view)
+	}
+}
+
+func TestCreateFlowRepoSelectView_ShowsAccumulatedModeHeader(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		[]PromptChoice{{Label: "example/repo-a", Value: "a"}},
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"repo",
+		"",
+	)
+
+	view := model.View()
+	if !strings.Contains(view, "• mode: repo") {
+		t.Fatalf("repo selection should show accumulated mode header, got: %q", view)
+	}
+	if !strings.Contains(view, "• repo:") {
+		t.Fatalf("repo selection should keep repo header line, got: %q", view)
+	}
+}
+
+func TestCreateFlowReviewRepoView_ShowsAccumulatedModeHeader(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		[]PromptChoice{{Label: "chatwork/terraforms", Value: "chatwork/terraforms"}},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"review",
+		"",
+	)
+
+	view := model.View()
+	if !strings.Contains(view, "• mode: review") {
+		t.Fatalf("review repo selection should show accumulated mode header, got: %q", view)
+	}
+	if !strings.Contains(view, "• repo:") {
+		t.Fatalf("review repo selection should keep repo header line, got: %q", view)
+	}
+}
+
+func TestCreateFlowReviewPRsView_ShowsAccumulatedHeaders(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"review",
+		"",
+	)
+	model.stage = createStageReviewPRs
+	model.mode = "review"
+	model.reviewRepo = "chatwork/terraforms"
+	model.reviewPRModel = newMultiSelectModel("gion manifest add", "pull request", []PromptChoice{{Label: "#1", Value: "1"}}, DefaultTheme(), false)
+
+	view := model.View()
+	if !strings.Contains(view, "• mode: review") || !strings.Contains(view, "• repo: chatwork/terraforms") {
+		t.Fatalf("review PR selection should show accumulated headers, got: %q", view)
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -209,6 +209,72 @@ func TestMultiSelectModel_SpaceTogglesSelection(t *testing.T) {
 	}
 }
 
+func TestChoiceSelectView_ShowsSingleSelectAssistLines(t *testing.T) {
+	model := newChoiceSelectModel("title", "repo", []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
+		{Label: "example/repo-b", Value: "b"},
+	}, DefaultTheme(), false)
+	model.input.SetValue("repo")
+
+	view := model.View()
+	if !strings.Contains(view, "filter: repo") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "space/enter select") {
+		t.Fatalf("expected single-select hint line, got: %q", view)
+	}
+	if strings.Contains(view, "selected:") {
+		t.Fatalf("single-select should not show selected summary, got: %q", view)
+	}
+}
+
+func TestWorkspaceSelectView_ShowsSingleSelectAssistLines(t *testing.T) {
+	model := newWorkspaceSelectModel("title", []WorkspaceChoice{
+		{ID: "WS-1", Description: "first"},
+		{ID: "WS-2", Description: "second"},
+	}, DefaultTheme(), false)
+	model.input.SetValue("WS")
+
+	view := model.View()
+	if !strings.Contains(view, "filter: WS") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "space/enter select") {
+		t.Fatalf("expected single-select hint line, got: %q", view)
+	}
+	if strings.Contains(view, "selected:") {
+		t.Fatalf("single-select should not show selected summary, got: %q", view)
+	}
+}
+
+func TestChoiceSelectModel_SpaceSelectsCurrent(t *testing.T) {
+	model := newChoiceSelectModel("title", "repo", []PromptChoice{
+		{Label: "example/repo-a", Value: "a"},
+		{Label: "example/repo-b", Value: "b"},
+	}, DefaultTheme(), false)
+	model.cursor = 1
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next := updated.(choiceSelectModel)
+	if next.value != "b" || !next.done {
+		t.Fatalf("expected space to select b, got value=%q done=%v", next.value, next.done)
+	}
+}
+
+func TestWorkspaceSelectModel_SpaceSelectsCurrent(t *testing.T) {
+	model := newWorkspaceSelectModel("title", []WorkspaceChoice{
+		{ID: "WS-1", Description: "first"},
+		{ID: "WS-2", Description: "second"},
+	}, DefaultTheme(), false)
+	model.cursor = 1
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next := updated.(workspaceSelectModel)
+	if next.workspaceID != "WS-2" {
+		t.Fatalf("expected space to select WS-2, got %q", next.workspaceID)
+	}
+}
+
 func TestStableLayout_TruncatesLinesWithDots(t *testing.T) {
 	setWrapWidth(20)
 	defer setWrapWidth(0)

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -390,10 +390,13 @@ func TestCreateFlowReviewRepo_ConfirmAdvancesToPRSelection(t *testing.T) {
 		t.Fatalf("expected confirm timer command")
 	}
 
-	updated, _ = next.Update(singleSelectConfirmDoneMsg{})
+	updated, cmd = next.Update(singleSelectConfirmDoneMsg{})
 	next = updated.(createFlowModel)
 	if next.stage != createStageReviewPRs {
 		t.Fatalf("expected confirm to advance to PR selection, got %v", next.stage)
+	}
+	if cmd != nil {
+		t.Fatalf("expected no quit command after advancing to PR selection")
 	}
 }
 
@@ -429,10 +432,13 @@ func TestCreateFlowRepoSelect_ConfirmAdvancesToWorkspaceStep(t *testing.T) {
 		t.Fatalf("expected confirm timer command")
 	}
 
-	updated, _ = next.Update(singleSelectConfirmDoneMsg{})
+	updated, cmd = next.Update(singleSelectConfirmDoneMsg{})
 	next = updated.(createFlowModel)
 	if next.stage != createStageRepoWorkspace {
 		t.Fatalf("expected confirm to advance to repo workspace step, got %v", next.stage)
+	}
+	if cmd != nil {
+		t.Fatalf("expected no quit command after advancing to repo workspace step")
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -355,6 +355,87 @@ func TestCreateFlowMode_SpaceSelectsCurrentMode(t *testing.T) {
 	}
 }
 
+func TestCreateFlowReviewRepo_ConfirmAdvancesToPRSelection(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		[]PromptChoice{{Label: "chatwork/terraforms", Value: "chatwork/terraforms"}},
+		nil,
+		func(string) ([]PromptChoice, error) {
+			return []PromptChoice{{Label: "#1", Value: "1"}}, nil
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"review",
+		"",
+	)
+	model.cursor = 0
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(createFlowModel)
+	if !next.reviewRepoModel.confirming {
+		t.Fatalf("expected review repo to enter confirming state")
+	}
+	if cmd == nil {
+		t.Fatalf("expected confirm timer command")
+	}
+
+	updated, _ = next.Update(singleSelectConfirmDoneMsg{})
+	next = updated.(createFlowModel)
+	if next.stage != createStageReviewPRs {
+		t.Fatalf("expected confirm to advance to PR selection, got %v", next.stage)
+	}
+}
+
+func TestCreateFlowRepoSelect_ConfirmAdvancesToWorkspaceStep(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		[]PromptChoice{{Label: "chatwork/terraforms", Value: "chatwork/terraforms"}},
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"repo",
+		"",
+	)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(createFlowModel)
+	if !next.repoSelectModel.confirming {
+		t.Fatalf("expected repo select to enter confirming state")
+	}
+	if cmd == nil {
+		t.Fatalf("expected confirm timer command")
+	}
+
+	updated, _ = next.Update(singleSelectConfirmDoneMsg{})
+	next = updated.(createFlowModel)
+	if next.stage != createStageRepoWorkspace {
+		t.Fatalf("expected confirm to advance to repo workspace step, got %v", next.stage)
+	}
+}
+
 func TestChoiceSelectView_HidesAssistAndMutesOthersWhileConfirming(t *testing.T) {
 	model := newChoiceSelectModel("title", "repo", []PromptChoice{
 		{Label: "example/repo-a", Value: "a"},

--- a/internal/ui/prompt_workspace_repo_test.go
+++ b/internal/ui/prompt_workspace_repo_test.go
@@ -174,3 +174,32 @@ func TestWorkspaceRepoView_ShowsFocusMarkerOnSelectedRepo(t *testing.T) {
 		t.Fatalf("expected focused repo row marker, got: %q", out)
 	}
 }
+
+func TestWorkspaceRepoView_UsesFilterLineForActiveInput(t *testing.T) {
+	model := newWorkspaceRepoSelectModel("giongo", []WorkspaceChoice{
+		{
+			ID: "gion",
+			Repos: []PromptChoice{
+				{
+					Label:   "gion (branch: feature/test)",
+					Value:   "/ws/gion/gion",
+					Details: []string{"repo: github.com/tasuku43/gion"},
+				},
+			},
+		},
+	}, DefaultTheme(), false)
+	model.input.SetValue("gio")
+	model.filtered = model.filterWorkspaces()
+	model.rebuildSelections()
+
+	view := model.View()
+	if strings.Contains(view, "• workspace: gio") {
+		t.Fatalf("active filter should not be echoed in workspace repo header, got: %q", view)
+	}
+	if !strings.Contains(view, "filter: gio") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "\n\n  filter: gio") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
+	}
+}

--- a/internal/ui/prompt_workspace_repo_test.go
+++ b/internal/ui/prompt_workspace_repo_test.go
@@ -170,7 +170,7 @@ func TestWorkspaceRepoView_ShowsFocusMarkerOnSelectedRepo(t *testing.T) {
 	if !strings.Contains(out, ">") {
 		t.Fatalf("expected focused row marker in output, got: %q", out)
 	}
-	if !strings.Contains(out, ">     └─ gion (branch: feature/test)") {
+	if !strings.Contains(out, "  >   └─ gion (branch: feature/test)") {
 		t.Fatalf("expected focused repo row marker, got: %q", out)
 	}
 }

--- a/internal/ui/prompt_workspace_repo_test.go
+++ b/internal/ui/prompt_workspace_repo_test.go
@@ -1,6 +1,11 @@
 package ui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
 
 func TestWorkspaceRepoFilter_RepoMatchKeepsParent(t *testing.T) {
 	workspaces := []WorkspaceChoice{
@@ -143,5 +148,29 @@ func TestWorkspaceRepoBestSelectionPrefersRepoMatch(t *testing.T) {
 	}
 	if model.selections[best].RepoIndex < 0 {
 		t.Fatalf("expected repo selection, got workspace selection")
+	}
+}
+
+func TestWorkspaceRepoView_ShowsFocusMarkerOnSelectedRepo(t *testing.T) {
+	var b strings.Builder
+	renderWorkspaceRepoChoiceList(&b, []WorkspaceChoice{
+		{
+			ID: "gion",
+			Repos: []PromptChoice{
+				{
+					Label:   "gion (branch: feature/test)",
+					Value:   "/ws/gion/gion",
+					Details: []string{"repo: github.com/tasuku43/gion"},
+				},
+			},
+		},
+	}, 1, 20, true, DefaultTheme())
+
+	out := ansi.Strip(b.String())
+	if !strings.Contains(out, ">") {
+		t.Fatalf("expected focused row marker in output, got: %q", out)
+	}
+	if !strings.Contains(out, ">     └─ gion (branch: feature/test)") {
+		t.Fatalf("expected focused repo row marker, got: %q", out)
 	}
 }

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -62,7 +62,11 @@ func (r *Renderer) Step(text string) {
 
 func (r *Renderer) StepLog(text string) {
 	// Align nested logs with the Plan tree indentation.
-	r.writeWithPrefix(output.Indent+output.LogConnector+" ", r.style(text, r.theme.Muted))
+	prefix := output.Indent + output.LogConnector + " "
+	if r.useColor {
+		prefix = r.style(prefix, r.theme.Muted)
+	}
+	r.writeWithPrefix(prefix, r.style(text, r.theme.Muted))
 }
 
 func (r *Renderer) StepLogOutput(text string) {

--- a/internal/ui/renderer_step_test.go
+++ b/internal/ui/renderer_step_test.go
@@ -1,0 +1,20 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tasuku43/gion/internal/infra/output"
+)
+
+func TestRendererStepLog_FormatsWithConnector(t *testing.T) {
+	var b bytes.Buffer
+	renderer := NewRenderer(&b, DefaultTheme(), true)
+
+	renderer.StepLog("$ git worktree remove --force")
+
+	got := b.String()
+	if got != "  "+output.LogConnector+" $ git worktree remove --force\n" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

This PR aligns `gion`'s selector and prompt presentation more closely with the `kra` UI language while preserving `gion`'s own flow-oriented behavior.

The branch contains multiple incremental UI commits, so this PR description is grouped by behavior and user-facing outcome rather than by commit.

## Background

The main goals of this work are:

- make `gion` and `kra` feel related as tools from the same family
- improve selector readability and consistency, especially for single-select and multi-select flows
- keep `gion`'s task flow intact even when borrowing `kra`'s selection language
- bring `giongo` closer to the same visual vocabulary where it makes sense

## What Changed

### 1. Added a dedicated `gion` selector spec

Documentation was added and linked so the intended selector behavior is explicit on the `gion` side, instead of implicitly depending on `kra`.

Files:
- `docs/spec/ui/UI-SELECTOR.md`
- `docs/spec/ui/UI.md`
- `docs/spec/ui/UI-ARCH.md`

The spec documents the current direction:
- adopt `kra`-style selector language and visual cues
- preserve `gion`'s own flow semantics where needed
- keep the implementation local to `gion` for now instead of prematurely extracting a shared library

### 2. Reworked `gion` single-select and multi-select presentation

The main selector work lives in `internal/ui/prompt.go`.

#### Single-select

Single-select prompts now use a much more `kra`-like interaction model:
- `>` focus marker
- `○ / ●` selection markers
- `filter:` input line
- single-select footer hints (`space/enter select`, `type filter`, `esc cancel`)
- short confirm state after selection
- selected row marked with `●`
- unselected rows muted during confirm
- assist lines hidden during confirm
- ~0.2s delay before advancing

This behavior was applied to:
- the create-flow mode selector in `gion manifest add`
- generic choice selectors
- workspace single-select selectors

#### Multi-select

Multi-select prompts now follow the same selector language:
- `>` focus marker
- `○ / ●` toggle state in-list
- `space toggle`
- `enter apply`
- `filter:` input line
- selected count footer
- confirm phase on apply
- assist lines hidden during confirm
- unselected rows muted during confirm
- ~0.2s delay before exit/apply

This was applied to:
- generic multi-select
- workspace multi-select
- review PR selection in create-flow

### 3. Fixed create-flow transition bugs introduced by confirm behavior

During the selector alignment work, nested create-flow selectors exposed a couple of bugs:

- single-select confirm completion messages were being swallowed by the parent create-flow model
- nested selector timer commands were being dropped
- some stage transitions advanced and then immediately quit

Those issues were fixed so flows like the following now work correctly:
- `gion manifest add` -> `review` -> repo select -> PR select
- `gion manifest add` -> `repo` -> repo select -> workspace / description flow

This was especially important after adding delayed confirm states.

### 4. Separated header state from filter input

Selectors were previously echoing active user input in the main `Inputs` header line in some places, which made the role of the filter ambiguous.

This PR makes the contract more consistent:
- header lines represent selected / fixed context
- `filter:` represents active typed query

Examples of the new behavior:
- `mode:` stays as context, not active search text
- `repo:` / `pull request:` / `workspace:` stay as context lines
- the current search term appears only in `filter:`

This applies across single-select, multi-select, create-flow selectors, and `giongo`'s workspace selector.

### 5. Accumulated selected context across `manifest add` create-flow

The `Inputs` section now keeps previously selected context visible as the flow progresses.

Examples:
- after picking mode `repo`, the next selector shows `mode: repo`
- after picking review mode and repo, the PR selector shows both `mode: review` and `repo: <selected repo>`
- selected values accumulate instead of disappearing between stages

This makes the flow easier to follow and better matches the mental model of “building up” a command interactively.

### 6. Improved `giongo` workspace selector presentation

`giongo` was brought closer to the same selector vocabulary without forcing it into exactly the same behavior as `gion`/`kra`.

Changes include:
- visible `>` focus marker for the selected line
- adjusted focus marker indentation to align with the tree layout
- removed duplicated `branch:` detail lines when branch is already shown in the repo label
- moved active input to `filter:` instead of echoing typed text in the header line
- added the same blank line before filter assist lines for consistency

Files:
- `internal/cli/giongo.go`
- `internal/ui/prompt.go`
- related tests

### 7. Added spacing consistency around selector assist lines and sections

Selector assist lines now render with a blank line before the `filter:` / footer block, which makes the main list easier to scan.

Also, `Frame` handling was adjusted so blank raw lines can be represented intentionally when rendering prompt UIs.

### 8. Muted apply log connectors

In `Apply` output, nested log connectors like `└─` are now rendered as muted along with the rest of the nested command/log line instead of standing out at primary emphasis.

This affects output such as:
- `git worktree remove --force ...`

File:
- `internal/ui/renderer.go`

## Files of Interest

Primary implementation files:
- `internal/ui/prompt.go`
- `internal/ui/frame.go`
- `internal/ui/renderer.go`
- `internal/cli/giongo.go`

Primary test files:
- `internal/ui/prompt_scroll_test.go`
- `internal/ui/prompt_workspace_repo_test.go`
- `internal/ui/renderer_step_test.go`
- `internal/cli/giongo_test.go`

Docs:
- `docs/spec/ui/UI-SELECTOR.md`
- `docs/spec/ui/UI.md`
- `docs/spec/ui/UI-ARCH.md`

## Testing

Ran:

- `go test ./internal/ui -count=1`
- targeted `internal/cli` tests around `giongo`
- targeted selector and renderer tests while iterating on prompt behavior

## Notes for Reviewers

A few notes that may help review:

- This branch contains several iterative commits because the UI was refined in response to actual prompt output and flow bugs discovered while testing.
- The core design choice is deliberate: borrow `kra`'s selector language and confirm presentation, but keep `gion`'s command flow semantics where that is a better fit.
- `giongo` is intentionally only partially aligned; the goal there is family resemblance, not forced identity.

## Follow-ups (Not Included Here)

Potential next steps after this PR:
- unify section spacing rules for final human output through shared helpers, similar to `kra`'s section rendering contract
- continue reviewing `Info / Result / Apply` spacing for consistency outside prompt UIs
- decide whether any selector primitives are stable enough to share across tools later
