### PR TITLE
Align prompt UI structure and apply summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,9 @@
   - `gion import`: the filesystem (+ `.gion/metadata.json`) is the source of truth; gion rebuilds `gion.yaml`.
 - Command roles:
   - `gion plan`: **read-only** (no side effects). Shows the diff between `gion.yaml` and the filesystem.
-  - `gion apply`: **reconcile**. Output is `Plan` → (confirm y/n) → `Apply` → `Result`
-    - The confirmation prompt is shown at the end of the `Plan` section (with a blank line before the prompt).
-    - `Apply` prints steps plus partial git command logs (tree-style).
+  - `gion apply`: **reconcile**. Output is `Plan` → `Step` (interactive confirm only) → `Apply` → `Result`
+    - The confirmation prompt is rendered as a `Step` section between `Plan` and `Apply`.
+    - Normal `Apply` output is summarized at the workspace / repo level rather than dumping raw git commands.
     - `Result` prints a completion summary (applied counts / manifest rewrite, etc.).
   - `gion import`: **rebuild inventory**. Reconstructs/normalizes `gion.yaml` from the current filesystem.
 - Non-negotiables:
@@ -55,7 +55,7 @@
   - Instead, compute everything up front and render via `applyManifestMutation` hooks:
     - `ShowPrelude` for user-provided inputs (interactive selections / flag-driven args).
     - `RenderInfoBeforeApply` for derived metadata (warnings, scanned/candidates counts, computed candidate lists, etc.).
-  - Rationale: emitting sections before `applyManifestMutation` often leads to ordering drift (`Info` before `Inputs`) or duplicated `Info` sections.
+  - Rationale: emitting sections before `applyManifestMutation` often leads to ordering drift (`Info` before `Context`) or duplicated `Info` sections.
 - When you know the related issue for a PR, include the issue link/number in the PR body(e.g. Fixes #<issue-number>).
 - Command specs live in `docs/spec/commands/` (YAML frontmatter with `status`):
     - `status: planned` means spec-first discussion; implement only after consensus and flip to `implemented`.

--- a/README.md
+++ b/README.md
@@ -248,18 +248,11 @@ This enables:
 - shell completion in the same setup step
 - `giongo` navigation without a separate `giongo init` step
 
-Example (zsh function):
+This command installs both shell wrappers for you:
 
 ```bash
-giongo() {
-  if [[ "$1" == "init" || "$1" == "--help" || "$1" == "-h" || "$1" == "--version" || "$1" == "--print" ]]; then
-    command giongo "$@"
-    return $?
-  fi
-  local dest
-  dest="$(command giongo --print "$@")" || return $?
-  [[ -n "$dest" ]] && cd "$dest"
-}
+gion() { ... }
+giongo() { ... }
 ```
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Worktree sprawl brings pain:
 gion makes it safe and repeatable: declare task workspaces in YAML, review diffs (including deletion risk), then create and clean them up in bulk.  
 You don’t have to edit YAML directly—`gion manifest ...` lets you add/remove workspaces interactively and updates the inventory behind the scenes.
 
-https://github.com/user-attachments/assets/70da3e63-2bfe-4cca-b5a4-ffc8c153eb4a
-
 ## Who it’s for
 
 - Developers working on tasks that span multiple repositories.

--- a/README.md
+++ b/README.md
@@ -248,13 +248,6 @@ This enables:
 - shell completion in the same setup step
 - `giongo` navigation without a separate `giongo init` step
 
-This command installs both shell wrappers for you:
-
-```bash
-gion() { ... }
-giongo() { ... }
-```
-
 Notes:
 - `gion shell init` is the primary shell integration path for `gion` commands.
 - `gion shell init` also installs the `giongo` shell wrapper.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Add a workspace interactively (example output, trimmed):
 gion manifest add
 ```
 ```bash
-Inputs
+Context
+  • mode: repo
   • repo: git@github.com:org/backend.git
   • workspace id: PROJ-123
   • repo #1 (git@github.com:org/backend.git)
@@ -114,14 +115,15 @@ Plan
     └─ backend (branch: PROJ-123-sample)
        repo: github.com/org/backend
 
+Step
   • Apply changes? (default: No) (y/n)
-    └─ y
+
+  input: y
+  enter confirm  esc cancel
 
 Apply
   • create workspace PROJ-123
-  • worktree add backend
-  └─ $ git worktree add -b PROJ-123-sample …/workspaces/PROJ-123/backend origin/main
-     (git output trimmed)
+    └─ backend (branch: PROJ-123-sample)
 
 Result
   • applied: add=1 update=0 remove=0
@@ -163,14 +165,15 @@ Example plan (add + remove, trimmed):
 ```text
 Plan
   • + add workspace PROJ-123
-    └─ backend  PROJ-123
-       repo: github.com/org/backend.git
+    └─ backend (branch: PROJ-123)
+       repo: github.com/org/backend
   • - remove workspace PROJ-099
-    └─ backend  PROJ-099
+    └─ backend (branch: PROJ-099)
        risk: dirty (unstaged=2)
        sync: upstream=origin/main ahead=1 behind=0
 
-Apply destructive changes? (default: No)
+Step
+  • Apply destructive changes? (default: No) (y/n)
 ```
 
 ### Create workspaces

--- a/docs/spec/commands/apply.md
+++ b/docs/spec/commands/apply.md
@@ -43,8 +43,10 @@ Reconcile the filesystem to match `gion.yaml` by computing a diff, showing a pla
 
 ## Output (IA)
 - `Plan` section: plan summary (same as `gion plan`).
-  - When interactive, the final confirmation prompt is rendered at the end of `Plan` (with a blank line before it).
-- `Apply` section: execution steps, with partial git command logs nested under each step.
+  - When interactive, the confirmation UI is rendered as a `Step` section between `Plan` and `Apply`.
+  - Once confirmation completes, the `Step` prompt should not remain in the final visible transcript.
+- `Apply` section: execution summary at the workspace / repo level.
+  - Normal output should not dump raw git commands such as `git worktree add` / `git worktree remove`.
 - `Result` section: completion summary (e.g. applied counts) and manifest rewrite note.
 
 ## Flags

--- a/docs/spec/commands/import.md
+++ b/docs/spec/commands/import.md
@@ -22,7 +22,7 @@ Rebuild `gion.yaml` from the filesystem and `.gion/metadata.json` to restore the
 - `--no-prompt` is accepted but currently has no effect (kept for CLI consistency).
 
 ## Output
-- `Inputs` section (optional):
+- `Context` section (optional):
   - Omitted when running with the default root and no flags.
   - Prints `root: <path>` when shown.
   - Prints `no-prompt: true` only when `--no-prompt` is provided.

--- a/docs/spec/commands/manifest/add.md
+++ b/docs/spec/commands/manifest/add.md
@@ -22,7 +22,7 @@ Create the desired workspace inventory in `gion.yaml` using an interactive UX, t
 - If none are provided and prompts are allowed, enter an interactive mode picker.
   - The picker presents `preset`, `repo`, `review`, `issue` and supports arrow selection with filterable search.
 - If none are provided and `--no-prompt` is set, error.
-- When prompts are used, mode flags still run the unified prompt flow so the `Inputs` section is rendered as a single in-place interaction.
+- When prompts are used, mode flags still run the unified prompt flow so `Context` and `Step` are rendered as one in-place interaction.
 - The optional positional `[<WORKSPACE_ID>]` overrides the default workspace ID derivation for single-workspace flows.
   - This is supported only for `--preset` and `--repo` (single-workspace flows).
   - For `--review` and `--issue`, the workspace ID is derived mechanically from the URL metadata; providing `[<WORKSPACE_ID>]` is an error.
@@ -136,11 +136,13 @@ Defaults and `--branch` rules:
 
 ## Output (IA)
 - Always uses the common sectioned layout from `docs/spec/ui/UI.md`.
-- `Inputs`: interactive UX inputs (mode, repo/preset, workspace id, branch/base, etc).
+- Interactive flows render `Context` and `Step`:
+  - `Context`: confirmed values plus the current unresolved field as a muted pending line.
+  - `Step`: the active selector, text input, or confirmation prompt.
 - `Plan`/`Apply`/`Result`: delegated to `gion apply` when apply is run.
 
 ### Info section (when apply runs)
-When apply runs, `gion manifest add` should emit an `Info` section after `Inputs` to make the two-phase behavior explicit:
+When apply runs, `gion manifest add` should emit an `Info` section after `Context` to make the two-phase behavior explicit:
 - `manifest: updated gion.yaml`
 - `apply: reconciling entire root (plan may include unrelated drift)`
 
@@ -149,11 +151,12 @@ When `--no-apply` is set, `gion manifest add` does not run apply and prints a sh
 
 Example:
 ```
-Inputs
+Context
   • mode: repo
   • repo: git@github.com:org/repo.git
   • workspace id: PROJ-123
-  • branch: PROJ-123
+  • repo #1 (git@github.com:org/repo.git)
+    └─ branch: PROJ-123
 
 Result
   • updated gion.yaml
@@ -163,7 +166,7 @@ Suggestion
 ```
 
 ### Output: with apply (default)
-When apply runs, `gion manifest add` prints `Inputs` first, then streams `gion apply` output (`Info`/`Plan`/`Apply`/`Result`).
+When apply runs, `gion manifest add` prints `Context` first, then streams `gion apply` output (`Info`/`Plan`/`Step` (while waiting for confirmation only)/`Apply`/`Result`).
 `gion manifest add` itself does not attempt to summarize the plan beyond what `gion apply` prints.
 
 ## Error messages (guidance)

--- a/docs/spec/commands/manifest/preset/add.md
+++ b/docs/spec/commands/manifest/preset/add.md
@@ -33,21 +33,26 @@ Create a preset entry in `gion.yaml` without manual YAML editing.
 - Candidate list is the fetched repos from `gion repo ls` (already in bare store). Unfetched repos are not shown.
 - Prompt behavior mirrors existing gion selection UI:
   - Shows a filterable list. Typing narrows candidates by substring match (case-insensitive). Optionally a lightweight fuzzy match is acceptable.
-  - The first visible item is highlighted. `<Enter>` adds the highlighted repo, removes it from the candidate list.
-  - The prompt loops, allowing repeated add operations. A minimum of 1 selection is required.
-  - Finish keys: `<Ctrl+D>` or typing `done` then `<Enter>`. If no repo has been added yet, finishing triggers an error message and returns to the prompt.
-  - Empty input + `<Enter>` does nothing (stays in the loop) to avoid accidental finish.
+  - The first visible item is highlighted with `>`.
+  - `Space` toggles the highlighted repo with `○/●` markers.
+  - `Enter` applies the selected set. A minimum of 1 selection is required.
+  - The active query is shown in the bottom `filter:` line, not in confirmed context.
 
 ## Output examples
 
 ### Output: interactive (no --repo)
 ```
-Inputs
-  • preset name: hel
-    └─ helmfiles
-  • repo: s
-    └─ git@github.com:org/repo.git
-    └─ git@github.com:org/api.git
+Context
+  • preset name: helmfiles
+  • repo:
+
+Step
+  • repo:
+    ○ git@github.com:org/repo.git
+  > ● git@github.com:org/api.git
+
+  filter: s
+  selected: 1/2  ↑↓ move  space toggle  enter apply  type filter  esc cancel
 
 Result
   • updated gion.yaml
@@ -55,7 +60,7 @@ Result
 
 ### Output: non-interactive (--repo)
 ```
-Inputs
+Context
   • preset name: helmfiles
   • repo: git@github.com:org/repo.git
   • repo: git@github.com:org/api.git

--- a/docs/spec/commands/manifest/preset/rm.md
+++ b/docs/spec/commands/manifest/preset/rm.md
@@ -33,19 +33,25 @@ Remove preset entries from `gion.yaml`.
 - Candidate list is the preset names in `gion.yaml`.
 - Prompt behavior mirrors existing gion selection UI:
   - Shows a filterable list. Typing narrows candidates by substring match (case-insensitive). Optionally a lightweight fuzzy match is acceptable.
-  - The first visible item is highlighted. `<Enter>` adds the highlighted preset name, removes it from the candidate list.
-  - The prompt loops, allowing repeated add operations.
-  - Finish keys: `<Ctrl+D>` or typing `done` then `<Enter>`.
-  - Empty input + `<Enter>` does nothing (stays in the loop) to avoid accidental finish.
+  - The first visible item is highlighted with `>`.
+  - `Space` toggles the highlighted preset with `○/●` markers.
+  - `Enter` applies the selected set.
+  - The active query is shown in the bottom `filter:` line.
 
 ## Output examples
 
 ### Output: interactive (no args)
 ```
-Inputs
-  • preset: he
-    └─ helpdesk
-    └─ helpers
+Context
+  • preset:
+
+Step
+  • preset:
+    ○ helpdesk
+  > ● helpers
+
+  filter: he
+  selected: 1/2  ↑↓ move  space toggle  enter apply  type filter  esc cancel
 
 Result
   • updated gion.yaml (removed 2 presets)
@@ -53,7 +59,7 @@ Result
 
 ### Output: non-interactive (args)
 ```
-Inputs
+Context
   • preset: helpdesk
 
 Result

--- a/docs/spec/commands/manifest/rm.md
+++ b/docs/spec/commands/manifest/rm.md
@@ -38,27 +38,35 @@ Remove workspace entries from the inventory (`gion.yaml`) using an interactive U
 
 ## Output (IA)
 - Always uses the common sectioned layout from `docs/spec/ui/UI.md`.
-- `Inputs`: selection inputs (workspace ids, short status tags, optional description).
+- Interactive flows render `Context` and `Step`:
+  - `Context`: confirmed state plus the current unresolved field as a muted pending line.
+  - `Step`: the active workspace selector or confirmation prompt.
 - `Plan`/`Apply`/`Result`: delegated to `gion apply` when apply is run.
 
-### Inputs section (interactive selection)
+### Step section (interactive selection)
 When no `<WORKSPACE_ID>` args are provided, the command enters an interactive multi-select picker.
 
 Picker guidance:
-- Search/filter is supported (filter text is shown as the input value in `Inputs`).
-- Multi-select is supported.
+- Search/filter is supported via the bottom `filter:` line in `Step`.
+- Multi-select uses in-list `○/●` markers.
 - Cancel/empty selection exits 0 with no changes.
 
 Example (interactive selection, conceptual):
 ```
-Inputs
-  • workspace: s
-    └─ PROJ-123 - fix login flow
-    └─ PROJ-999[dirty] - wip refactor
+Context
+  • workspace:
+
+Step
+  • workspace:
+    ○ PROJ-123 - fix login flow
+  > ● PROJ-999[dirty] - wip refactor
+
+  filter: s
+  selected: 1/2  ↑↓ move  space toggle  enter apply  type filter  esc cancel
 ```
 
 ### Info section (when apply runs)
-When apply runs, `gion manifest rm` should emit an `Info` section after `Inputs` to make the two-phase behavior explicit:
+When apply runs, `gion manifest rm` should emit an `Info` section after `Context` to make the two-phase behavior explicit:
 - `manifest: updated gion.yaml (removed N workspace(s))`
 - `apply: reconciling entire root (destructive removals require confirmation)`
 
@@ -86,9 +94,15 @@ Detection guidance:
 
 Example (interactive selection, conceptual):
 ```
-Inputs
-  • workspace: s
-    └─ PROJ-123 - fix login flow
+Context
+  • workspace:
+
+Step
+  • workspace:
+  > ○ PROJ-123 - fix login flow
+
+  filter: s
+  selected: 0/1  ↑↓ move  space toggle  enter apply  type filter  esc cancel
 ```
 
 ## Output examples
@@ -98,7 +112,7 @@ When `--no-apply` is set, `gion manifest rm` does not run apply and prints a sho
 
 Example:
 ```
-Inputs
+Context
   • workspace: PROJ-123
 
 Result
@@ -109,7 +123,7 @@ Suggestion
 ```
 
 ### Output: with apply (default)
-When apply runs, `gion manifest rm` prints `Inputs` first, then streams `gion apply` output (`Info`/`Plan`/`Apply`/`Result`).
+When apply runs, `gion manifest rm` prints `Context` first, then streams `gion apply` output (`Info`/`Plan`/`Step` (while waiting for confirmation only)/`Apply`/`Result`).
 `gion manifest rm` itself does not attempt to summarize the plan beyond what `gion apply` prints.
 
 ## Success Criteria

--- a/docs/spec/commands/repo/rm.md
+++ b/docs/spec/commands/repo/rm.md
@@ -15,7 +15,7 @@ Remove one or more bare repo stores under the gion root when they are unused by 
 - When multiple specs are provided, duplicates are removed while preserving order.
 - With no specs and prompts allowed:
   - Loads existing stores via `gion repo ls` and opens a filterable multi-select list.
-  - Selection UX matches `gion manifest preset rm`: `<Enter>` selects and removes from candidates; finish with `<Ctrl+D>` or `done`; minimum 1 selection required.
+  - Selection UX matches the current multi-select contract: `Space` toggles `○/●`, `Enter` applies, and the active query is shown in the bottom `filter:` line.
 - With no specs and `--no-prompt`, returns an error.
 - Before removing:
   - Resolves each repo spec to a canonical repo key (`host/owner/repo`) and store path (`<root>/bare/<host>/<owner>/<repo>.git`).

--- a/docs/spec/ui/UI-ARCH.md
+++ b/docs/spec/ui/UI-ARCH.md
@@ -5,48 +5,53 @@ status: implemented
 
 # UI Architecture
 
-This document describes the implementation structure (separation of concerns) that keeps the UI aligned with the UI.md contract.
+This document describes the implementation structure that keeps the terminal UI aligned with [UI.md](/Users/tasuku43/gionroot/workspaces/gion/gion/docs/spec/ui/UI.md).
 
 ## Goals
-- Always guarantee the fixed section order: Inputs → Info → Steps → Result → Suggestion
-- Avoid per-command bespoke rendering; enforce the contract through shared components
-- Prevent duplicate Inputs output during interactive flows (update in-place instead)
+- Guarantee the fixed section order for the active flow
+- Avoid per-command bespoke rendering
+- Keep prompt state and reconcile summaries aligned with one shared contract
 - Keep selector implementations aligned with [UI-SELECTOR.md](/Users/tasuku43/gionroot/workspaces/gion/gion/docs/spec/ui/UI-SELECTOR.md)
 
 ## Components
 
 ### Frame (`internal/ui/frame.go`)
-**Responsibilities**
-- A single container that centralizes section ordering and rendering rules
-- Holds `Inputs/Info/Steps/Result/Suggestion` content and renders them in a fixed order
 
-**Usage**
-- `SetInputsPrompt(...)` sets prompt lines
-- `AppendInputsRaw(...)` appends already-formatted list/tree lines
-- `SetInfo(...)` / `AppendInfoRaw(...)` manage auxiliary info
+Responsibilities:
+- Centralize `Context / Info / Step / Result / Suggestion` ordering
+- Hold already-classified lines and render them with consistent spacing
 
-**Key points**
-- Frame owns the screen structure
-- Each UI updates only the content
+Usage:
+- `SetContextPrompt(...)` / `AppendContextRaw(...)` for confirmed and pending context
+- `SetStepPrompt(...)` / `AppendStepRaw(...)` for the active selector, text input, or confirmation
+- `SetInfo(...)` / `AppendInfoRaw(...)` for warnings, blocked items, and auxiliary metadata
+
+Key points:
+- `Frame` owns prompt-screen structure
+- Prompt models should update content only, not section ordering
+- `Plan` / `Apply` remain CLI-rendered sections outside `Frame`
 
 ### Renderer (`internal/ui/renderer.go`)
-**Responsibilities**
-- Low-level rendering of headers, bullets, steps, and tree lines
-- Invoked by Frame or CLI render paths
+
+Responsibilities:
+- Low-level rendering of headers, bullets, raw lines, and tree indentation
+- Shared by both `Frame` and CLI output paths
 
 ### Prompt Models (`internal/ui/prompt.go`)
-**Responsibilities**
-- Input/selection state transitions and validation
-- `View()` should only update Inputs/Info via Frame
-- Selector-family behavior should be centralized here rather than duplicated in command handlers
+
+Responsibilities:
+- Own input / selection state transitions and validation
+- Render prompt flows through `Frame`
+- Centralize selector behavior instead of duplicating it in command handlers
 
 ## Implementation Rules
-- Do not print UI output directly with `fmt.Fprintf/Printf/Println` (use Renderer/Frame)
-- Consolidate prompts into `Inputs`, and auxiliary info into `Info`
-- Do not invent custom headers (e.g., “Selected”); fold them into `Info`
-- Do not use AltScreen; keep CLI output non-invasive (`tea.WithAltScreen` is not allowed)
+- Do not print UI output directly with `fmt.Fprintf/Printf/Println` in UI paths
+- Consolidate confirmed state into `Context`, active interaction into `Step`, and auxiliary state into `Info`
+- Do not invent ad-hoc sections for selected items or picker-specific summaries
+- Do not use AltScreen
 
 ## Applying to Existing Flows
-- Prefer a single Frame that updates across multiple prompt steps
-- Use `AppendInputsRaw(...)` for list/tree lines to keep the section order intact
-- Treat selector copy, finish hints, and selected-set rendering as shared UI behavior, not per-command wording
+- Prefer one `Frame` that updates across multiple prompt steps
+- Use `AppendContextRaw(...)` for pending context lines
+- Use `AppendStepRaw(...)` for selector rows, `filter:` / `input:` lines, and footers
+- Treat selector copy, assist-line wording, and confirm transitions as shared UI behavior

--- a/docs/spec/ui/UI-SELECTOR.md
+++ b/docs/spec/ui/UI-SELECTOR.md
@@ -6,55 +6,51 @@ status: proposed
 # Selector UI
 
 This document defines the `gion` selector contract for interactive pickers.
-It intentionally aligns with `kra` on visual language and terminal layout, while
-keeping `gion`'s flow-oriented interaction model.
+It intentionally aligns with `kra` on visual language and terminal layout,
+while keeping `gion`'s staged flow and summary-oriented apply behavior.
 
 ## Goals
-
 - Make `gion` and `kra` feel like the same family in terminal UI quality
-- Preserve `gion`'s input-flow orientation for manifest and workspace creation flows
-- Reduce per-picker drift by documenting one selector contract for `gion`
+- Preserve `gion`'s staged flow for manifest and workspace creation
+- Reduce per-picker drift by documenting one selector contract
 
 ## Design stance
 
-`gion` selectors are not a direct copy of `kra` selectors.
+`gion` does not need to copy `kra` interaction-for-interaction.
 
-- `kra` favors in-list toggle interaction for repeated operational tasks
-- `gion` favors staged input flows that move the user toward one apply action
-
-Because of that, `gion` keeps its own selection model, but should reuse the same
-visual grammar where possible:
-
+What should match:
 - stable section layout
-- consistent filter input placement
-- consistent muted/accent/error semantics
-- consistent focus visibility
-- consistent key-hint language
+- `>`, `○/●`, muted connectors, and assist-line language
+- consistent `filter:` / `input:` placement
+- consistent focus, confirm, and error handling
+
+What may differ:
+- whether a flow proceeds to another step or applies immediately
+- whether confirmation is visible only transiently
+- how command-specific context is accumulated above the selector
 
 ## Selector families
 
-`gion` currently uses two selector families.
-
 ### Single-select
 
-Used when the next step needs exactly one value.
+Used when the next stage needs exactly one value.
 
 Examples:
 - mode selection in create flows
 - repo selection in create flows
 - workspace selection in simple pickers
-- `giongo` workspace/repo selection
+- `giongo` workspace / repo selection
 
 Interaction:
 - `Up` / `Down`: move cursor
-- `Enter`: confirm focused row
+- `Space` / `Enter`: confirm focused row
 - `Esc` / `Ctrl+C`: cancel
 - typing: update filter query
 - `Backspace` / `Delete`: edit filter query
 
 ### Multi-select
 
-Used when the user builds a set and then proceeds to the next step or apply.
+Used when the user builds a set and then applies or advances once.
 
 Examples:
 - review PR selection
@@ -64,18 +60,11 @@ Examples:
 
 Interaction:
 - `Up` / `Down`: move cursor
-- `Enter`: add the focused item into the selected set
-- `Ctrl+D`: finish selection
-- `done` + `Enter`: finish selection
+- `Space`: toggle the focused item
+- `Enter`: apply the current selected set
 - `Esc` / `Ctrl+C`: cancel
 - typing: update filter query
 - `Backspace` / `Delete`: edit filter query
-
-Important distinction from `kra`:
-- `gion` multi-select is append-and-progress, not toggle-in-place
-- selected items may move out of the candidate list and into `Info`
-
-This is intentional and matches `gion`'s staged workflow design.
 
 ## Shared layout contract
 
@@ -83,102 +72,59 @@ Selectors must follow [UI.md](/Users/tasuku43/gionroot/workspaces/gion/gion/docs
 
 Rules:
 - keep selector content inside the shared `Frame`
-- selector input lives in `Inputs`
-- selected items, blocked items, and validation messages live in `Info`
-- do not introduce ad-hoc section names outside the shared section system
+- confirmed state lives in `Context`
+- the current unresolved field also appears in `Context` as a muted pending line
+- the active selector prompt, candidate list, and assist lines live in `Step`
+- blocked items and validation messages live in `Info`
+- do not introduce ad-hoc section names
 - do not use AltScreen
 
 For selector rendering:
-- the filter input line stays at the top of `Inputs`
-- the candidate list is rendered immediately below the input line
-- helper text such as finish hints is rendered after the candidate list
-- selected items are rendered in `Info`
-- blocked items, when present, are rendered after selected items in `Info`
+- the active prompt line stays at the top of `Step`
+- the candidate list is rendered immediately below the prompt line
+- `filter:` and the footer are rendered after the candidate list
+- confirm state may temporarily hide assist lines before the next stage
 
 ## Visual language
 
-To keep the family resemblance with `kra`, selectors should converge on the
-same terminal language even when the interaction differs.
-
 ### Focus
-
 - the focused row must be visually obvious
-- in color terminals, focused text may use bold and/or a subtle emphasis style
-- in no-color terminals, focus must remain understandable from row position alone
+- no-color terminals must still show focus through row markers and placement
 
 ### Selection state
-
-`gion` does not need to adopt `kra`'s `○/●` row markers everywhere.
-
-Instead:
-- candidate rows may remain compact and flow-oriented
-- the selected set must be visible as a separate list or tree in `Info`
-- the selected set should use accent for its heading and muted rendering for tree structure
+- use `○/●` markers for selector rows
+- single-select shows the confirmed or focused choice with `●`
+- multi-select keeps the selected set visible inline in the list
+- do not move selected items into a separate `Info` block in normal selector flows
 
 ### Text hierarchy
-
 - primary information: selected item labels, focused row content
-- muted information: descriptions, tree connectors, helper text
+- muted information: descriptions, connectors, helper text, pending context
 - error information: validation lines and blocking messages
-- accent information: selector labels and selected-set headings
+- accent information: active labels and selected markers
 
 ## Copy and hints
 
-Selector copy should be short and explicit.
-
 Recommended wording:
-- `finish: Ctrl+D or type "done"` for append-style multi-select
+- `filter:` for selector filtering
+- `input:` for text entry
 - `select at least one <item>` for empty-confirm validation
-- `no matches` when filter results are empty
-
-`gion` may keep its own finish hint instead of adopting `kra`'s footer contract,
-because the interaction model is different.
-
-However, wording should still feel related:
-- use imperative verbs
-- keep hint phrases short
-- prefer consistent English labels across commands
+- `no matches` when filtering returns nothing
+- `↑↓ move  space/enter select  type filter  esc cancel` for single-select
+- `selected: n/m  ↑↓ move  space toggle  enter apply  type filter  esc cancel` for multi-select
 
 ## Search behavior
-
-Filtering should feel consistent across selectors.
-
-Minimum contract:
 - case-insensitive
-- direct typing updates the filter immediately
-- `Backspace` and `Delete` modify the filter without entering a separate mode
-- when filter results shrink, cursor must stay within visible range
+- direct typing updates immediately
+- `Backspace` and `Delete` edit the query in place
+- when the result set shrinks, cursor must stay within visible range
 
-Current `gion` matching may remain simple substring-based where already implemented.
-If `gion` later adopts the same fuzzy ordered-subsequence matching as `kra`, that
-should be treated as an enhancement, not a compatibility requirement for this spec.
-
-## Multi-select behavior
-
-For append-style multi-select in `gion`:
-
-- `Enter` adds the focused item to the selected set
-- after adding, the item may be removed from remaining candidates
-- the filter may be cleared after addition when that helps repeated entry
-- finishing requires at least one selected item
-- selected items must remain reviewable before the next stage
-
-Recommended UX rules:
-- keep the selected set visible without scrolling away from the input
-- keep finish instructions visible near the candidate list
-- do not require remembering hidden controls
-- avoid mixing selected and blocked states into the same visual block
+Current matching may remain substring-based or fuzzy where already implemented.
 
 ## Architecture guidance
-
-`gion` should still avoid per-command bespoke selectors.
-
-Preferred direction:
 - keep selector state machines in `internal/ui/prompt.go`
-- reuse shared rendering helpers for candidate rows and selected trees
-- keep `Frame` responsible for section ordering
+- reuse shared rendering helpers for candidate rows, assist lines, and pending context lines
+- keep `Frame` responsible for prompt section ordering
 - keep command handlers responsible for supplying data, not formatting
 
-This does not require extracting a shared library with `kra`.
-That question should be revisited only after the interaction and visual contracts
-have stabilized independently in both projects.
+This does not require a shared extracted library with `kra` yet.

--- a/docs/spec/ui/UI.md
+++ b/docs/spec/ui/UI.md
@@ -6,199 +6,252 @@ status: implemented
 # UI Specification (Bubble Tea + Bubbles + Lip Gloss)
 
 ## Goals
-- Provide a quiet, consistent output experience (similar to Codex CLI)
-- Use Bubble Tea for interactive flows; use plain text for non-interactive flows
-- Keep the information architecture consistent across all commands
+- Provide a quiet, consistent terminal UI
+- Keep interactive and non-interactive output aligned under one information architecture
+- Make prompt flows feel related to `kra` without forcing identical behavior
 
 ## Scope
 - Interactive (TTY): Bubble Tea + Bubbles + Lip Gloss
-- Non-interactive (non-TTY): plain text (no TUI), same layout rules
+- Non-interactive (non-TTY): plain text with the same layout rules
 
 ## Layout (common)
-Sectioned layout. Inputs appear first when present; Info/Suggestion are optional:
+
+`gion` uses two related section families.
+
+- Prompt flows use `Context` and `Step`
+- Reconcile flows use `Info`, `Plan`, `Step` (optional confirm), `Apply`, and `Result`
+
+Prompt-oriented layout:
 
 ```
-Inputs
-  <input line>
-  <input line>
+Context
+  <confirmed value>
+  <pending muted value>
 
 Info
-  <warnings / skipped / blocked>
+  <warnings / blocked / auxiliary meta>
 
-Plan
-  <plan line>
-  <plan line>
-
-Steps
-  <step line>
-  <step line>
+Step
+  <active selector or question>
+  <filter/input/footer>
 
 Result
   <result line>
-  <tree>
 
 Suggestion
   <next command>
 ```
 
+Reconcile-oriented layout:
+
+```
+Context
+  <optional prelude from manifest mutation commands>
+
+Info
+  <manifest updated / warning lines>
+
+Plan
+  <plan line>
+  <plan line>
+
+Step
+  <optional confirmation prompt>
+
+Apply
+  <execution summary>
+  <workspace -> repo tree>
+
+Result
+  <result line>
+```
+
 Rules:
 - Indent: 2 spaces
 - 1 blank line between sections
-- Section order is fixed: Inputs → Info → Plan → Steps → Result → Suggestion
-- Result summary lines are bullets (use the same prefix as Steps)
-- Multi-line blocks (e.g. unified diffs) may be rendered as indented raw lines under `Result` without bullet prefixes
-- No success banner; success is implied in Result section
-- Long lines should wrap to the terminal width; continuation lines keep the same text indent (prefix width).
-  - Exception: interactive picker lists should truncate long lines with `...` to keep a stable cursor→row mapping.
-  - When truncation would hide the user-entered value at the end of a long label (e.g. per-repo branch inputs), prefer a 2-line layout: label on its own line, then an indented `branch: <value>` line.
+- Section order is fixed within the active flow:
+  - Prompt flow: `Context -> Info -> Step -> Result -> Suggestion`
+  - Reconcile flow: `Context -> Info -> Plan -> Step -> Apply -> Result`
+- Not every screen renders every section
+- No success banner; success is implied in `Result`
+- Long lines should wrap to terminal width; continuation lines keep the same text indent
+  - Exception: interactive selector rows should truncate with `...` when stable cursor-to-row mapping matters
+  - When truncation would hide the user-entered value at the end of a long label, prefer a 2-line layout: label on one line, then an indented detail line such as `branch: <value>`
 
 Notes:
-- IaC-style commands use `Plan`/`Apply`:
-  - `gion plan`: renders `Info` (optional) then `Plan` only.
-  - `gion apply`: renders `Info` (optional) → `Plan` → `Apply` (execution steps + git logs) → `Result`.
-- `Apply` is semantically the same as `Steps`, but reserved for execution output in reconcile flows.
-- Prompts may appear inside a section when it improves flow readability (e.g. `gion apply` renders the final y/n confirmation prompt at the end of `Plan` with a blank line before it).
+- `gion plan` renders `Info` (optional) then `Plan`
+- `gion apply` renders `Info` (optional) -> `Plan` -> `Step` (interactive confirm only) -> `Apply` -> `Result`
+- In normal output, `Apply` should summarize work at the workspace / repo level rather than dump raw git commands
+- After confirmation completes, the `Step` prompt should not remain in the final visible transcript
 
 ## Prefix & Indentation
-- Default prefix token: `•` (can be changed later)
-- Steps/list lines are prefixed with `2 spaces + prefix + space`
-- Result lines are prefixed with `2 spaces + prefix + space`
+- Default prefix token: `•`
+- Context / Info / Step / Result lines use `2 spaces + prefix + space` unless they are already formatted raw tree lines
+- Tree/list indentation must use shared tokens from `internal/infra/output`
 
 Prefix coloring:
-- Info/list (Steps, Results): prefix is muted gray
-- Prompts/questions (e.g. run now?): prefix + label use accent (cyan)
-- Optional details (repo lines under workspace): muted gray
+- Info / Result / tree connectors: muted gray
+- Prompts and active labels: accent
+- Warnings: yellow
+- Errors: red
 
 Example:
+
 ```
-Steps
-  • repo get git@github.com:org/repo.git -> bare/github.com/org/repo.git
-  • worktree add repo -> workspaces/PROJ-123/repo
+Apply
+  • create workspace PROJ-123
+    └─ backend (branch: PROJ-123)
 ```
 
 ## Command execution logs
-- Steps may include user-facing command logs.
-- Use muted color (low contrast, non-flashy).
-- Command output lines can be visually connected using tree glyphs.
-- Debug logging is written to files when `--debug` is provided (no on-screen Debug section).
+- Raw command logs should not appear in normal `Apply` output
+- If commands are shown at all, render them in muted color
+- Debug logging belongs in files when `--debug` is provided; do not add a visible `Debug` section
 
-Example:
-```
-Steps
-  • repo get git@github.com:org/repo.git
-    └─ $ git clone --bare ...
-```
-
-## Colors (fixed)
+## Colors
 - success: green
 - warn: yellow
 - error: red
-- muted/log: low-contrast gray
-- accent/meta: cyan (for metadata like branch)
+- muted / log / connectors: low-contrast gray
+- accent / active labels: cyan
 
-## Components (Bubble Tea)
-- Text input: Bubbles textinput
-- Select/confirm: Bubbles list or simple radio
-- Spinners: optional; use subtle style only
-- Help line: muted color, minimal content
-- Long selection lists should scroll so Inputs stay visible.
+## Components
+- Text input: Bubbles `textinput`
+- Selector / confirm: Bubble Tea models backed by shared rendering helpers
+- Help line: muted, minimal
+- Long selection lists should scroll so `Context` and `Step` remain visible
 
 Selector-specific interaction and visual rules are documented in
 [UI-SELECTOR.md](/Users/tasuku43/gionroot/workspaces/gion/gion/docs/spec/ui/UI-SELECTOR.md).
 
-## Pickers
+## Workspace picker line format
 
-Pickers in `gion` are flow-oriented by default. They should share visual language
-with `kra`, but are not required to copy `kra`'s in-list toggle model.
-
-### Workspace picker line format
-When rendering workspace candidates (e.g. in `gion manifest rm`), use a compact single-line display:
+When rendering workspace candidates (for example in `gion manifest rm`), use:
 
 `<WORKSPACE_ID>[<status>] - <description>`
 
 Rules:
-- `<description>` is optional; omit ` - <description>` when empty.
-- Repo details should not be shown in the picker (deep review happens in the subsequent plan output).
-- `<status>` is a short aggregated label based on workspace scan:
-  - `dirty`, `unpushed`, `diverged`, `unknown`
-  - `clean` should be treated as the default and omitted (no status tag).
-- If multiple conditions apply, the status tag should be the highest priority item:
-  - `unknown` > `dirty` > `diverged` > `unpushed` (clean is omitted).
-- Semantics and detection guidance for these labels are defined by the command specs (e.g. `gion manifest rm`).
+- `<description>` is optional
+- Repo details should not be shown in the picker; deep review belongs in `Plan`
+- `<status>` is omitted for clean workspaces
+- Priority when multiple conditions apply:
+  - `unknown` > `dirty` > `diverged` > `unpushed`
 
-Color guidance (TTY):
-- `<WORKSPACE_ID>`: default text color.
-- `[unpushed]` / `[diverged]`: warn (yellow).
-- `[dirty]` / `[unknown]`: error (red).
-- ` - <description>`: muted gray.
-
-Example:
-`PROJ-123 - fix login flow`
+Color guidance:
+- `<WORKSPACE_ID>`: default text color
+- `[unpushed]` / `[diverged]`: warn
+- `[dirty]` / `[unknown]`: error
+- description: muted
 
 ## Examples
 
-### gion manifest add --preset (interactive)
+### `gion manifest add` (mode picker)
+
 ```
-Inputs
-  • preset: hel
-    └─ helmfiles
+Context
+  • mode:
+
+Step
+  • mode:
+  > ○ repo - 1 repo only
+    ○ issue - From an issue (multi-select, GitHub only)
+    ○ review - From a review request (multi-select, GitHub only)
+    ○ preset - From preset
+
+  filter: s
+  ↑↓ move  space/enter select  type filter  esc cancel
+```
+
+### `gion manifest add --preset` (interactive)
+
+```
+Context
+  • mode: preset
+  • preset: helmfiles
   • workspace id: PROJ-123
 
 Info
-  • (optional warnings / skipped / blocked)
+  • manifest: updated gion.yaml
 
-Steps
-  • worktree add helmfiles
-
-Result
-  • /Users/me/gion/workspaces/PROJ-123
+Plan
+  • + add workspace PROJ-123
     └─ helmfiles (branch: PROJ-123)
-```
+       repo: github.com/org/helmfiles
 
-### gion manifest add (mode picker)
-```
-Inputs
-  • mode: s
-    ├─ repo - 1 repo only
-    ├─ issue - From an issue (multi-select, GitHub only)
-    ├─ review - From a review request (multi-select, GitHub only)
-    └─ preset - From preset
-```
+Step
+  • Apply changes? (default: No) (y/n)
 
-### gion manifest add --preset (non-interactive)
-```
-Steps
-  • repo get git@github.com:org/repo.git
-  • worktree add repo
+  input: y
+  enter confirm  esc cancel
+
+Apply
+  • create workspace PROJ-123
+    └─ helmfiles (branch: PROJ-123)
 
 Result
-  • /Users/me/gion/workspaces/PROJ-123
-    ├─ repo
-    └─ api
+  • applied: add=1 update=0 remove=0
+  • gion.yaml rewritten
 ```
 
-### gion manifest add --review (interactive)
+### `gion manifest add --review` (interactive multi-select)
+
 ```
-Steps
-  • repo get required for 1 repo
-    └─ gion repo get git@github.com:org/repo.git
-  • run now? (y/n)
+Context
+  • mode: review
+  • repo: git@github.com:org/repo.git
+  • pull request:
+
+Step
+  • pull request:
+    ○ #101 fix example
+  > ● #102 align prompt UI
+
+  filter:
+  selected: 1/2  ↑↓ move  space toggle  enter apply  type filter  esc cancel
 ```
 
-### gion plan
+### `gion manifest add --preset` (`--no-apply`)
+
+```
+Context
+  • mode: preset
+  • preset: app
+  • workspace id: PROJ-123
+  • repo #1 (git@github.com:org/repo.git)
+    └─ branch: PROJ-123
+
+Result
+  • updated gion.yaml
+
+Suggestion
+  gion apply
+```
+
+### `gion apply`
+
 ```
 Plan
-  • workspace add PROJ-123
-  • worktree add api (branch: PROJ-123)
+  • - remove workspace PROJ-099
+    └─ backend (branch: PROJ-099)
+       sync: upstream=origin/main ahead=1 behind=0
+
+Step
+  • Apply destructive changes? (default: No) (y/n)
+
+  input: y
+  enter confirm  esc cancel
+
+Apply
+  • remove workspace PROJ-099
+    └─ backend (branch: PROJ-099)
 ```
 
 ## Notes
-- Prefix token is a theme value and can be changed later.
-- All prompts and labels are English.
-- Info section is optional and may include warnings/skipped/blocked items, selection state, and inline help/auxiliary meta.
-- Errors should be emphasized with a red prefix and red text.
-- Suggestion section is optional and shown only on TTY with colors enabled (e.g. `cd <path>`).
+- All prompts and labels are English
+- `Info` is optional and may include warnings, blocked items, or derived metadata
+- `Suggestion` is optional and shown only on TTY with colors enabled
 
 ## Implementation contract
-- CLI output must use `ui.Renderer` (or `internal/infra/output` helpers) and must not write directly to stdout via `fmt.Fprintf/Printf/Println` in UI paths.
-- Result lines must be rendered using `Bullet()` to enforce consistent prefixing.
+- CLI output must use `ui.Renderer` or `internal/infra/output` helpers
+- Prompt models must use `Frame` rather than writing ad-hoc section headers
+- Result lines must be rendered via `Bullet()`-style helpers to preserve prefix consistency

--- a/internal/app/apply/apply.go
+++ b/internal/app/apply/apply.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tasuku43/gion/internal/domain/repo"
 	"github.com/tasuku43/gion/internal/domain/workspace"
 	"github.com/tasuku43/gion/internal/infra/gitcmd"
+	"github.com/tasuku43/gion/internal/infra/output"
 )
 
 type Options struct {
@@ -104,17 +105,21 @@ func applyWorkspaceAdd(ctx context.Context, rootDir string, desired manifest.Fil
 		fetch = false
 	}
 	for _, repoEntry := range ws.Repos {
-		logStep(opts.Step, fmt.Sprintf("worktree add %s", repoEntry.Alias))
+		beginRepoGroup(repoEntry.Alias, repoEntry.Branch)
 		if strings.EqualFold(strings.TrimSpace(ws.Mode), workspace.MetadataModeReview) {
 			if err := applyReviewRepoAdd(ctx, rootDir, change.WorkspaceID, repoEntry); err != nil {
+				endRepoGroup()
 				return err
 			}
+			endRepoGroup()
 			continue
 		}
 		_, createdBranch, baseBranch, err := add.AddRepo(ctx, rootDir, change.WorkspaceID, repoEntry.RepoKey, repoEntry.Alias, repoEntry.Branch, repoEntry.BaseRef, fetch)
 		if err != nil {
+			endRepoGroup()
 			return err
 		}
+		endRepoGroup()
 		if createdBranch {
 			baseBranchToRecord, baseBranchMixed = coreapplyplan.UpdateBaseBranchCandidate(baseBranchToRecord, baseBranchMixed, baseBranch)
 		}
@@ -170,25 +175,35 @@ func applyReviewRepoAdd(ctx context.Context, rootDir, workspaceID string, repoEn
 }
 
 func applyRepoRemovals(ctx context.Context, rootDir string, change manifestplan.WorkspaceChange, opts Options) error {
+	if !hasRepoRemovalChanges(change) {
+		return nil
+	}
+	logStep(opts.Step, fmt.Sprintf("update workspace %s", change.WorkspaceID))
 	for _, repoChange := range change.Repos {
 		switch repoChange.Kind {
 		case manifestplan.RepoRemove, manifestplan.RepoUpdate:
 			if coreapplyplan.IsInPlaceBranchRename(repoChange) {
 				continue
 			}
-			logStep(opts.Step, fmt.Sprintf("worktree remove %s", repoChange.Alias))
+			beginRepoGroup(repoChange.Alias, repoChange.FromBranch)
 			if err := remove_repo.RemoveRepo(ctx, rootDir, change.WorkspaceID, repoChange.Alias, remove_repo.Options{
 				AllowDirty:       opts.AllowDirty,
 				AllowStatusError: opts.AllowStatusError,
 			}); err != nil {
+				endRepoGroup()
 				return err
 			}
+			endRepoGroup()
 		}
 	}
 	return nil
 }
 
 func applyRepoBranchRenames(ctx context.Context, rootDir string, change manifestplan.WorkspaceChange, step func(text string)) error {
+	if !hasInPlaceBranchRenameChanges(change) {
+		return nil
+	}
+	logStep(step, fmt.Sprintf("update workspace %s", change.WorkspaceID))
 	for _, repoChange := range change.Repos {
 		if !coreapplyplan.IsInPlaceBranchRename(repoChange) {
 			continue
@@ -203,15 +218,21 @@ func applyRepoBranchRenames(ctx context.Context, rootDir string, change manifest
 			return fmt.Errorf("cannot rename branch: repo %q is on %q, want %q", repoChange.Alias, currentBranch, repoChange.FromBranch)
 		}
 
-		logStep(step, fmt.Sprintf("branch rename %s", repoChange.Alias))
+		beginRepoGroup(repoChange.Alias, repoChange.ToBranch)
 		if err := gitcmd.BranchMove(ctx, worktreePath, repoChange.FromBranch, repoChange.ToBranch); err != nil {
+			endRepoGroup()
 			return err
 		}
+		endRepoGroup()
 	}
 	return nil
 }
 
 func applyRepoAdds(ctx context.Context, rootDir string, desired manifest.File, change manifestplan.WorkspaceChange, opts Options) error {
+	if !hasRepoAddChanges(change) {
+		return nil
+	}
+	logStep(opts.Step, fmt.Sprintf("update workspace %s", change.WorkspaceID))
 	baseBranchToRecord := ""
 	baseBranchMixed := false
 	fetch := true
@@ -221,12 +242,14 @@ func applyRepoAdds(ctx context.Context, rootDir string, desired manifest.File, c
 	for _, repoChange := range change.Repos {
 		switch repoChange.Kind {
 		case manifestplan.RepoAdd:
-			logStep(opts.Step, fmt.Sprintf("worktree add %s", repoChange.Alias))
+			beginRepoGroup(repoChange.Alias, repoChange.ToBranch)
 			baseRef := desiredBaseRef(desired, change.WorkspaceID, repoChange.Alias)
 			_, createdBranch, baseBranch, err := add.AddRepo(ctx, rootDir, change.WorkspaceID, repoChange.ToRepo, repoChange.Alias, repoChange.ToBranch, baseRef, fetch)
 			if err != nil {
+				endRepoGroup()
 				return err
 			}
+			endRepoGroup()
 			if createdBranch {
 				baseBranchToRecord, baseBranchMixed = coreapplyplan.UpdateBaseBranchCandidate(baseBranchToRecord, baseBranchMixed, baseBranch)
 			}
@@ -234,12 +257,14 @@ func applyRepoAdds(ctx context.Context, rootDir string, desired manifest.File, c
 			if coreapplyplan.IsInPlaceBranchRename(repoChange) {
 				continue
 			}
-			logStep(opts.Step, fmt.Sprintf("worktree add %s", repoChange.Alias))
+			beginRepoGroup(repoChange.Alias, repoChange.ToBranch)
 			baseRef := desiredBaseRef(desired, change.WorkspaceID, repoChange.Alias)
 			_, createdBranch, baseBranch, err := add.AddRepo(ctx, rootDir, change.WorkspaceID, repoChange.ToRepo, repoChange.Alias, repoChange.ToBranch, baseRef, fetch)
 			if err != nil {
+				endRepoGroup()
 				return err
 			}
+			endRepoGroup()
 			if createdBranch {
 				baseBranchToRecord, baseBranchMixed = coreapplyplan.UpdateBaseBranchCandidate(baseBranchToRecord, baseBranchMixed, baseBranch)
 			}
@@ -259,6 +284,58 @@ func logStep(step func(text string), text string) {
 		return
 	}
 	step(text)
+}
+
+func beginRepoGroup(alias, branch string) {
+	output.BeginGroup(formatApplyRepoLabel(alias, branch))
+}
+
+func endRepoGroup() {
+	output.EndGroup()
+}
+
+func formatApplyRepoLabel(alias, branch string) string {
+	name := strings.TrimSpace(alias)
+	if name == "" {
+		name = "repo"
+	}
+	if strings.TrimSpace(branch) == "" {
+		return name
+	}
+	return fmt.Sprintf("%s (branch: %s)", name, strings.TrimSpace(branch))
+}
+
+func hasRepoRemovalChanges(change manifestplan.WorkspaceChange) bool {
+	for _, repoChange := range change.Repos {
+		if repoChange.Kind == manifestplan.RepoRemove {
+			return true
+		}
+		if repoChange.Kind == manifestplan.RepoUpdate && !coreapplyplan.IsInPlaceBranchRename(repoChange) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasInPlaceBranchRenameChanges(change manifestplan.WorkspaceChange) bool {
+	for _, repoChange := range change.Repos {
+		if coreapplyplan.IsInPlaceBranchRename(repoChange) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRepoAddChanges(change manifestplan.WorkspaceChange) bool {
+	for _, repoChange := range change.Repos {
+		if repoChange.Kind == manifestplan.RepoAdd {
+			return true
+		}
+		if repoChange.Kind == manifestplan.RepoUpdate && !coreapplyplan.IsInPlaceBranchRename(repoChange) {
+			return true
+		}
+	}
+	return false
 }
 
 func ensureNoIncompleteWorkspaceRemoval(rootDir, workspaceID string) error {

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -111,7 +111,6 @@ func runApplyInternalWithPlan(ctx context.Context, rootDir string, renderer *ui.
 		}
 	}
 
-	renderer.Blank()
 	renderer.Section("Apply")
 	stepLogger := ui.NewGroupedStepLogger(renderer)
 	output.SetStepLogger(stepLogger)

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -61,8 +61,6 @@ func runApplyInternalWithPlan(ctx context.Context, rootDir string, renderer *ui.
 	if renderer == nil {
 		renderer = ui.NewRenderer(os.Stdout, theme, useColor)
 	}
-	output.SetStepLogger(renderer)
-	defer output.SetStepLogger(nil)
 
 	var warningLines []string
 	for _, warn := range plan.Warnings {
@@ -115,6 +113,9 @@ func runApplyInternalWithPlan(ctx context.Context, rootDir string, renderer *ui.
 
 	renderer.Blank()
 	renderer.Section("Apply")
+	stepLogger := ui.NewGroupedStepLogger(renderer)
+	output.SetStepLogger(stepLogger)
+	defer output.SetStepLogger(nil)
 	prefetchOK := true
 	if err := prefetch.WaitAll(ctx, toPrefetch); err != nil {
 		// ここでのfetch失敗はネットワーク要因が多く、apply自体は継続できることもあるため、
@@ -129,8 +130,10 @@ func runApplyInternalWithPlan(ctx context.Context, rootDir string, renderer *ui.
 		PrefetchOK:       prefetchOK,
 		Step:             output.Step,
 	}); err != nil {
+		stepLogger.Flush()
 		return applyInternalResult{HadChanges: true, Confirmed: confirmed, Applied: false}, err
 	}
+	stepLogger.Flush()
 	if err := rebuildManifest(ctx, rootDir); err != nil {
 		return applyInternalResult{HadChanges: true, Confirmed: confirmed, Applied: false}, err
 	}

--- a/internal/cli/apply_integration_test.go
+++ b/internal/cli/apply_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tasuku43/gion/internal/app/create"
@@ -94,6 +95,13 @@ func TestApply_BranchRenameInPlace_SucceedsWithDirtyWorktree(t *testing.T) {
 	if branch != "WS-2" {
 		t.Fatalf("branch: got %q, want %q", branch, "WS-2")
 	}
+	out := buf.String()
+	if !strings.Contains(out, "Apply\n  • update workspace WS-1\n    └─ repo (branch: WS-2)\n") {
+		t.Fatalf("apply output missing summary repo line:\n%s", out)
+	}
+	if strings.Contains(out, "git branch -m") {
+		t.Fatalf("apply output should not show raw git command:\n%s", out)
+	}
 
 	rewritten, err := manifest.Load(rootDir)
 	if err != nil {
@@ -105,5 +113,63 @@ func TestApply_BranchRenameInPlace_SucceedsWithDirtyWorktree(t *testing.T) {
 	}
 	if ws.Repos[0].Branch != "WS-2" {
 		t.Fatalf("rewritten branch: got %q, want %q", ws.Repos[0].Branch, "WS-2")
+	}
+}
+
+func TestApply_WorkspaceAdd_RendersSummaryOnly(t *testing.T) {
+	t.Setenv("GIT_AUTHOR_NAME", "gion")
+	t.Setenv("GIT_AUTHOR_EMAIL", "gion@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "gion")
+	t.Setenv("GIT_COMMITTER_EMAIL", "gion@example.com")
+
+	ctx := context.Background()
+	tmp := t.TempDir()
+	rootDir := filepath.Join(tmp, "gion")
+
+	repoSpec, _ := setupLocalRemoteRepoExampleDotCom(t, tmp)
+	if _, err := repo.Get(ctx, rootDir, repoSpec); err != nil {
+		t.Fatalf("repo get: %v", err)
+	}
+
+	desired := manifest.File{
+		Version: 1,
+		Workspaces: map[string]manifest.Workspace{
+			"WS-2": {
+				Mode: workspace.MetadataModeRepo,
+				Repos: []manifest.Repo{
+					{
+						Alias:   "repo",
+						RepoKey: "example.com/org/repo",
+						Branch:  "WS-2",
+					},
+				},
+			},
+		},
+	}
+	if err := manifest.Save(rootDir, desired); err != nil {
+		t.Fatalf("manifest save: %v", err)
+	}
+
+	plan, err := manifestplan.Plan(ctx, rootDir)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+
+	var buf bytes.Buffer
+	renderer := ui.NewRenderer(&buf, ui.DefaultTheme(), false)
+	got, err := runApplyInternalWithPlan(ctx, rootDir, renderer, true, plan)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !got.Applied {
+		t.Fatalf("expected applied, got %+v", got)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Apply\n  • create workspace WS-2\n    └─ repo (branch: WS-2)\n") {
+		t.Fatalf("apply output missing summary repo line:\n%s", out)
+	}
+	if strings.Contains(out, "git worktree add") {
+		t.Fatalf("apply output should not show raw git command:\n%s", out)
 	}
 }

--- a/internal/cli/manifest_add.go
+++ b/internal/cli/manifest_add.go
@@ -116,6 +116,7 @@ func runManifestAdd(ctx context.Context, rootDir string, args []string, globalNo
 					r.Bullet("no changes")
 				},
 				RenderInfoBeforeApply: func(r *ui.Renderer, plan manifestplan.Result, planOK bool) {
+					r.Blank()
 					r.Section("Info")
 					r.Bullet(fmt.Sprintf("manifest: updated %s", manifest.FileName))
 					if planOK && planIncludesChangesOutsideWorkspaceIDs(plan, addedWorkspaceIDs) {

--- a/internal/cli/manifest_gc.go
+++ b/internal/cli/manifest_gc.go
@@ -248,6 +248,7 @@ func runManifestGc(ctx context.Context, rootDir string, args []string, globalNoP
 				r.Bullet("no changes")
 			},
 			RenderInfoBeforeApply: func(r *ui.Renderer, plan manifestplan.Result, _ bool) {
+				r.Blank()
 				r.Section("Info")
 				renderManifestGcInfo(r, candidates, warningLines)
 				r.Bullet(r.AccentText("manifest:") + " " + r.SuccessText("updated") + " " + manifest.FileName + " (" + r.ErrorText(fmt.Sprintf("removed %d workspace(s)", len(candidateIDs))) + ")")

--- a/internal/cli/manifest_mutation.go
+++ b/internal/cli/manifest_mutation.go
@@ -64,9 +64,6 @@ func applyManifestMutation(ctx context.Context, rootDir string, updated manifest
 		return nil
 	}
 
-	if opts.Hooks.ShowPrelude != nil {
-		renderer.Blank()
-	}
 	if opts.Hooks.RenderInfoBeforeApply != nil {
 		opts.Hooks.RenderInfoBeforeApply(renderer, plan, planOK)
 		renderer.Blank()

--- a/internal/cli/manifest_mutation_test.go
+++ b/internal/cli/manifest_mutation_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tasuku43/gion/internal/ui"
+)
+
+func TestManifestMutation_PreludeAndInfoHaveBlankLineBetween(t *testing.T) {
+	var b bytes.Buffer
+	r := ui.NewRenderer(&b, ui.DefaultTheme(), false)
+
+	r.Section("Inputs")
+	r.Prompt("mode: preset")
+	r.Prompt("preset: gion")
+	r.Prompt("workspace id: test")
+	r.Blank()
+	r.Section("Info")
+	r.Bullet("manifest: updated gion.yaml")
+
+	out := b.String()
+	if !strings.Contains(out, "workspace id: test\n\nInfo\n") {
+		t.Fatalf("expected a blank line before Info section, got: %q", out)
+	}
+}

--- a/internal/cli/manifest_rm.go
+++ b/internal/cli/manifest_rm.go
@@ -139,6 +139,7 @@ func runManifestRm(ctx context.Context, rootDir string, args []string, globalNoP
 				r.Bullet("no changes")
 			},
 			RenderInfoBeforeApply: func(r *ui.Renderer, _ manifestplan.Result, _ bool) {
+				r.Blank()
 				if !selectedFromPrompt {
 					r.Section("Info")
 				}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -234,7 +234,7 @@ func renderPlanWorkspaceAddRepos(renderer *ui.Renderer, changes []manifestplan.R
 			prefix = output.TreeBranchLast
 		}
 		prefix = baseIndent + prefix
-		detailPrefix := baseIndent + detailTreePrefix(i == len(adds)-1)
+		detailPrefix := baseIndent + output.DetailTreePrefix(i == len(adds)-1)
 		name := strings.TrimSpace(change.Alias)
 		if name == "" {
 			name = strings.TrimSpace(change.ToRepo)
@@ -258,7 +258,7 @@ func renderPlanWorkspaceUpdateRepos(renderer *ui.Renderer, change manifestplan.W
 			prefix = output.TreeBranchLast
 		}
 		prefix = baseIndent + prefix
-		detailPrefix := baseIndent + detailTreePrefix(i == len(change.Repos)-1)
+		detailPrefix := baseIndent + output.DetailTreePrefix(i == len(change.Repos)-1)
 
 		name := strings.TrimSpace(repoChange.Alias)
 		if name == "" {
@@ -376,7 +376,7 @@ func renderWorkspaceRiskDetails(renderer *ui.Renderer, status workspace.StatusRe
 		label := formatRepoLabel(name, repoEntry.Branch)
 		renderer.TreeLineBranchMuted(prefix, label, "")
 
-		detailPrefix := extraIndent + detailTreePrefix(i == len(status.Repos)-1)
+		detailPrefix := extraIndent + output.DetailTreePrefix(i == len(status.Repos)-1)
 		lines := buildRepoRiskDetailLines(renderer, repoEntry)
 		for _, line := range lines {
 			if strings.TrimSpace(ansi.Strip(line)) == "" {
@@ -392,13 +392,6 @@ func renderWorkspaceRiskDetails(renderer *ui.Renderer, status workspace.StatusRe
 		}
 		renderer.TreeLine(renderer.MutedText(extraIndent+output.TreeBranchLast), renderer.WarnText(fmt.Sprintf("warning: %s", msg)))
 	}
-}
-
-func detailTreePrefix(isLast bool) string {
-	if isLast {
-		return output.TreeStemLast
-	}
-	return output.TreeStemMid
 }
 
 func buildRepoRiskDetailLines(r *ui.Renderer, repo workspace.RepoStatus) []string {

--- a/internal/domain/workspace/remove.go
+++ b/internal/domain/workspace/remove.go
@@ -96,6 +96,9 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 		if repoLabel == "" {
 			repoLabel = filepath.Base(strings.TrimSpace(repo.WorktreePath))
 		}
+		if branch := strings.TrimSpace(repo.Branch); branch != "" {
+			repoLabel += fmt.Sprintf(" (branch: %s)", branch)
+		}
 		output.BeginGroup(repoLabel)
 		if force {
 			output.Log("$ git worktree remove --force")

--- a/internal/domain/workspace/remove.go
+++ b/internal/domain/workspace/remove.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/tasuku43/gion/internal/infra/gitcmd"
+	"github.com/tasuku43/gion/internal/infra/output"
 	"github.com/tasuku43/gion/internal/infra/paths"
 	"github.com/tasuku43/gion/internal/infra/shellaction"
 )
@@ -91,12 +92,19 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 			return fmt.Errorf("missing worktree path for alias %q", repo.Alias)
 		}
 		force := opts.AllowDirty
-		if force {
-			gitcmd.Logf("git worktree remove --force %s", repo.WorktreePath)
-		} else {
-			gitcmd.Logf("git worktree remove %s", repo.WorktreePath)
+		repoLabel := strings.TrimSpace(repo.Alias)
+		if repoLabel == "" {
+			repoLabel = filepath.Base(strings.TrimSpace(repo.WorktreePath))
 		}
+		output.BeginGroup(repoLabel)
+		if force {
+			output.Log("$ git worktree remove --force")
+		} else {
+			output.Log("$ git worktree remove")
+		}
+		output.Log(repo.WorktreePath)
 		if err := worktreeRemoveFn(ctx, repo.StorePath, repo.WorktreePath, force); err != nil {
+			output.EndGroup()
 			state.LastError = fmt.Sprintf("remove worktree %q: %v", repo.Alias, err)
 			state.UpdatedAt = removeStateNow()
 			if saveErr := SaveRemoveState(rootDir, state); saveErr != nil {
@@ -104,6 +112,7 @@ func RemoveWithOptions(ctx context.Context, rootDir, workspaceID string, opts Re
 			}
 			return fmt.Errorf("remove worktree %q: %w", repo.Alias, err)
 		}
+		output.EndGroup()
 		state.RemovedAliases = append(state.RemovedAliases, repo.Alias)
 		state.PendingAliases = removePendingAlias(state.PendingAliases, repo.Alias)
 		state.UpdatedAt = removeStateNow()

--- a/internal/infra/output/output.go
+++ b/internal/infra/output/output.go
@@ -23,6 +23,13 @@ const (
 	TreeStemLast   = "   "
 )
 
+func DetailTreePrefix(isLast bool) string {
+	if isLast {
+		return TreeStemLast
+	}
+	return TreeStemMid
+}
+
 type StepLogger interface {
 	Step(text string)
 	Log(text string)

--- a/internal/infra/output/output.go
+++ b/internal/infra/output/output.go
@@ -36,6 +36,11 @@ type StepLogger interface {
 	LogOutput(text string)
 }
 
+type GroupingStepLogger interface {
+	BeginGroup(text string)
+	EndGroup()
+}
+
 var stepLogger StepLogger
 var stepIndex uint64
 
@@ -67,6 +72,20 @@ func Log(text string) {
 
 func Logf(format string, args ...any) {
 	Log(fmt.Sprintf(format, args...))
+}
+
+func BeginGroup(text string) {
+	if logger, ok := stepLogger.(GroupingStepLogger); ok {
+		logger.BeginGroup(text)
+		return
+	}
+	Log(text)
+}
+
+func EndGroup() {
+	if logger, ok := stepLogger.(GroupingStepLogger); ok {
+		logger.EndGroup()
+	}
 }
 
 func LogOutput(text string) {

--- a/internal/ui/create_flow_test.go
+++ b/internal/ui/create_flow_test.go
@@ -28,3 +28,48 @@ func TestCreateFlow_PresetBranchInput_UsesSeparateInputLine(t *testing.T) {
 		t.Fatalf("expected separateInputLine=true for preset branch input")
 	}
 }
+
+func TestCreateFlow_PresetSelect_PropagatesConfirmTimerAndAdvances(t *testing.T) {
+	m := newCreateFlowModel(
+		"gion manifest add",
+		[]string{"gion"},
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		func(string) ([]string, error) { return []string{"git@github.com:tasuku43/gion.git"}, nil },
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"preset",
+		"",
+	)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(createFlowModel)
+	if !next.presetModel.confirming {
+		t.Fatalf("expected preset selector to enter confirming state")
+	}
+	if cmd == nil {
+		t.Fatalf("expected preset selector to return confirm timer command")
+	}
+
+	updated, cmd = next.Update(singleSelectConfirmDoneMsg{})
+	next = updated.(createFlowModel)
+	if next.stage != createStagePreset {
+		t.Fatalf("expected create flow to remain on preset stage until workspace id is entered, got %v", next.stage)
+	}
+	if next.presetModel.stage != stageWorkspace {
+		t.Fatalf("expected preset selector to advance to workspace input stage, got %v", next.presetModel.stage)
+	}
+	if cmd != nil {
+		t.Fatalf("expected no quit command after advancing to workspace input stage")
+	}
+}

--- a/internal/ui/frame.go
+++ b/internal/ui/frame.go
@@ -7,9 +7,9 @@ import (
 
 // Frame renders a single-screen layout with fixed section order.
 type Frame struct {
-	Inputs     []frameLine
+	Context    []frameLine
 	Info       []frameLine
-	Steps      []frameLine
+	Step       []frameLine
 	Result     []frameLine
 	Suggestion []frameLine
 
@@ -23,24 +23,48 @@ func NewFrame(theme Theme, useColor bool) *Frame {
 	return &Frame{theme: theme, useColor: useColor}
 }
 
-func (f *Frame) SetInputs(lines ...string) {
-	f.Inputs = copyLines(lines, lineBullet)
+func (f *Frame) SetContext(lines ...string) {
+	f.Context = copyLines(lines, lineBullet)
 }
 
-func (f *Frame) SetInputsPrompt(lines ...string) {
-	f.Inputs = copyLines(lines, linePrompt)
+func (f *Frame) SetContextPrompt(lines ...string) {
+	f.Context = copyLines(lines, linePrompt)
 }
 
-func (f *Frame) AppendInputsPrompt(lines ...string) {
-	f.Inputs = append(f.Inputs, copyLines(lines, linePrompt)...)
+func (f *Frame) AppendContextPrompt(lines ...string) {
+	f.Context = append(f.Context, copyLines(lines, linePrompt)...)
 }
 
-func (f *Frame) SetInputsRaw(lines ...string) {
-	f.Inputs = copyRawLines(lines)
+func (f *Frame) SetContextRaw(lines ...string) {
+	f.Context = copyRawLines(lines)
 }
 
-func (f *Frame) AppendInputsRaw(lines ...string) {
-	f.Inputs = append(f.Inputs, copyRawLines(lines)...)
+func (f *Frame) AppendContextRaw(lines ...string) {
+	f.Context = append(f.Context, copyRawLines(lines)...)
+}
+
+func (f *Frame) SetStep(lines ...string) {
+	f.Step = copyLines(lines, lineBullet)
+}
+
+func (f *Frame) SetStepPrompt(lines ...string) {
+	f.Step = copyLines(lines, linePrompt)
+}
+
+func (f *Frame) AppendStep(lines ...string) {
+	f.Step = append(f.Step, copyLines(lines, lineBullet)...)
+}
+
+func (f *Frame) AppendStepPrompt(lines ...string) {
+	f.Step = append(f.Step, copyLines(lines, linePrompt)...)
+}
+
+func (f *Frame) SetStepRaw(lines ...string) {
+	f.Step = copyRawLines(lines)
+}
+
+func (f *Frame) AppendStepRaw(lines ...string) {
+	f.Step = append(f.Step, copyRawLines(lines)...)
 }
 
 func (f *Frame) SetInfo(lines ...string) {
@@ -67,14 +91,6 @@ func (f *Frame) AppendInfoRaw(lines ...string) {
 	f.Info = append(f.Info, copyRawLines(lines)...)
 }
 
-func (f *Frame) SetSteps(lines ...string) {
-	f.Steps = copyLines(lines, lineStep)
-}
-
-func (f *Frame) AppendSteps(lines ...string) {
-	f.Steps = append(f.Steps, copyLines(lines, lineStep)...)
-}
-
 func (f *Frame) SetResult(lines ...string) {
 	f.Result = copyLines(lines, lineBullet)
 }
@@ -97,12 +113,12 @@ func (f *Frame) WriteTo(w io.Writer) (int64, error) {
 	cw := &countingWriter{w: w}
 	r := NewRenderer(cw, f.theme, f.useColor)
 
-	if len(f.Inputs) > 0 {
-		r.Section("Inputs")
-		for _, line := range f.Inputs {
+	if len(f.Context) > 0 {
+		r.Section("Context")
+		for _, line := range f.Context {
 			renderLine(r, line)
 		}
-		if len(f.Info) > 0 || len(f.Steps) > 0 || len(f.Result) > 0 || len(f.Suggestion) > 0 {
+		if len(f.Info) > 0 || len(f.Step) > 0 || len(f.Result) > 0 || len(f.Suggestion) > 0 {
 			r.Blank()
 		}
 	}
@@ -112,14 +128,14 @@ func (f *Frame) WriteTo(w io.Writer) (int64, error) {
 		for _, line := range f.Info {
 			renderLine(r, line)
 		}
-		if !f.NoBlankAfterInfo && (len(f.Steps) > 0 || len(f.Result) > 0 || len(f.Suggestion) > 0) {
+		if !f.NoBlankAfterInfo && (len(f.Step) > 0 || len(f.Result) > 0 || len(f.Suggestion) > 0) {
 			r.Blank()
 		}
 	}
 
-	if len(f.Steps) > 0 {
-		r.Section("Steps")
-		for _, line := range f.Steps {
+	if len(f.Step) > 0 {
+		r.Section("Step")
+		for _, line := range f.Step {
 			renderLine(r, line)
 		}
 		if len(f.Result) > 0 || len(f.Suggestion) > 0 {
@@ -197,6 +213,26 @@ func renderLine(r *Renderer, line frameLine) {
 	default:
 		r.Bullet(line.text)
 	}
+}
+
+func (f *Frame) SetInputs(lines ...string) {
+	f.SetContext(lines...)
+}
+
+func (f *Frame) SetInputsPrompt(lines ...string) {
+	f.SetContextPrompt(lines...)
+}
+
+func (f *Frame) AppendInputsPrompt(lines ...string) {
+	f.AppendContextPrompt(lines...)
+}
+
+func (f *Frame) SetInputsRaw(lines ...string) {
+	f.SetContextRaw(lines...)
+}
+
+func (f *Frame) AppendInputsRaw(lines ...string) {
+	f.AppendContextRaw(lines...)
 }
 
 func copyLines(lines []string, kind frameLineKind) []frameLine {

--- a/internal/ui/grouped_step_logger.go
+++ b/internal/ui/grouped_step_logger.go
@@ -1,0 +1,76 @@
+package ui
+
+import "github.com/tasuku43/gion/internal/infra/output"
+
+type groupedStepLogger struct {
+	renderer   *Renderer
+	current    *groupedStep
+	currentLog *groupedStepLog
+}
+
+type groupedStep struct {
+	title string
+	logs  []groupedStepLog
+}
+
+type groupedStepLog struct {
+	text    string
+	outputs []string
+}
+
+func NewGroupedStepLogger(renderer *Renderer) *groupedStepLogger {
+	return &groupedStepLogger{renderer: renderer}
+}
+
+func (l *groupedStepLogger) Step(text string) {
+	l.Flush()
+	l.current = &groupedStep{title: text}
+}
+
+func (l *groupedStepLogger) Log(text string) {
+	if l.renderer == nil {
+		return
+	}
+	if l.current == nil {
+		l.renderer.StepLog(text)
+		return
+	}
+	l.current.logs = append(l.current.logs, groupedStepLog{text: text})
+	l.currentLog = &l.current.logs[len(l.current.logs)-1]
+}
+
+func (l *groupedStepLogger) LogOutput(text string) {
+	if l.renderer == nil {
+		return
+	}
+	if l.current == nil || l.currentLog == nil {
+		l.renderer.StepLogOutput(text)
+		return
+	}
+	l.currentLog.outputs = append(l.currentLog.outputs, text)
+}
+
+func (l *groupedStepLogger) Flush() {
+	if l.renderer == nil || l.current == nil {
+		return
+	}
+
+	l.renderer.Step(l.current.title)
+	for i, entry := range l.current.logs {
+		prefix := output.TreeBranchMid
+		if i == len(l.current.logs)-1 {
+			prefix = output.TreeBranchLast
+		}
+		l.renderer.TreeLine(
+			l.renderer.MutedText(output.Indent+prefix),
+			l.renderer.MutedText(entry.text),
+		)
+		detailPrefix := l.renderer.MutedText(output.Indent + output.DetailTreePrefix(i == len(l.current.logs)-1))
+		for _, line := range entry.outputs {
+			l.renderer.TreeLine(detailPrefix, l.renderer.MutedText(line))
+		}
+	}
+
+	l.current = nil
+	l.currentLog = nil
+}

--- a/internal/ui/grouped_step_logger.go
+++ b/internal/ui/grouped_step_logger.go
@@ -3,19 +3,21 @@ package ui
 import "github.com/tasuku43/gion/internal/infra/output"
 
 type groupedStepLogger struct {
-	renderer   *Renderer
-	current    *groupedStep
-	currentLog *groupedStepLog
+	renderer     *Renderer
+	current      *groupedStep
+	currentGroup *groupedStepNode
+	currentNode  *groupedStepNode
 }
 
 type groupedStep struct {
 	title string
-	logs  []groupedStepLog
+	nodes []*groupedStepNode
 }
 
-type groupedStepLog struct {
-	text    string
-	outputs []string
+type groupedStepNode struct {
+	title    string
+	outputs  []string
+	children []*groupedStepNode
 }
 
 func NewGroupedStepLogger(renderer *Renderer) *groupedStepLogger {
@@ -27,6 +29,25 @@ func (l *groupedStepLogger) Step(text string) {
 	l.current = &groupedStep{title: text}
 }
 
+func (l *groupedStepLogger) BeginGroup(text string) {
+	if l.renderer == nil {
+		return
+	}
+	if l.current == nil {
+		l.renderer.StepLog(text)
+		return
+	}
+	node := &groupedStepNode{title: text}
+	l.current.nodes = append(l.current.nodes, node)
+	l.currentGroup = node
+	l.currentNode = nil
+}
+
+func (l *groupedStepLogger) EndGroup() {
+	l.currentGroup = nil
+	l.currentNode = nil
+}
+
 func (l *groupedStepLogger) Log(text string) {
 	if l.renderer == nil {
 		return
@@ -35,19 +56,24 @@ func (l *groupedStepLogger) Log(text string) {
 		l.renderer.StepLog(text)
 		return
 	}
-	l.current.logs = append(l.current.logs, groupedStepLog{text: text})
-	l.currentLog = &l.current.logs[len(l.current.logs)-1]
+	node := &groupedStepNode{title: text}
+	if l.currentGroup != nil {
+		l.currentGroup.children = append(l.currentGroup.children, node)
+	} else {
+		l.current.nodes = append(l.current.nodes, node)
+	}
+	l.currentNode = node
 }
 
 func (l *groupedStepLogger) LogOutput(text string) {
 	if l.renderer == nil {
 		return
 	}
-	if l.current == nil || l.currentLog == nil {
+	if l.current == nil || l.currentNode == nil {
 		l.renderer.StepLogOutput(text)
 		return
 	}
-	l.currentLog.outputs = append(l.currentLog.outputs, text)
+	l.currentNode.outputs = append(l.currentNode.outputs, text)
 }
 
 func (l *groupedStepLogger) Flush() {
@@ -56,21 +82,33 @@ func (l *groupedStepLogger) Flush() {
 	}
 
 	l.renderer.Step(l.current.title)
-	for i, entry := range l.current.logs {
+	l.renderNodes(output.Indent, l.current.nodes)
+
+	l.current = nil
+	l.currentGroup = nil
+	l.currentNode = nil
+}
+
+func (l *groupedStepLogger) renderNodes(baseIndent string, nodes []*groupedStepNode) {
+	for i, node := range nodes {
 		prefix := output.TreeBranchMid
-		if i == len(l.current.logs)-1 {
+		if i == len(nodes)-1 {
 			prefix = output.TreeBranchLast
 		}
 		l.renderer.TreeLine(
-			l.renderer.MutedText(output.Indent+prefix),
-			l.renderer.MutedText(entry.text),
+			l.renderer.MutedText(baseIndent+prefix),
+			l.renderer.MutedText(node.title),
 		)
-		detailPrefix := l.renderer.MutedText(output.Indent + output.DetailTreePrefix(i == len(l.current.logs)-1))
-		for _, line := range entry.outputs {
-			l.renderer.TreeLine(detailPrefix, l.renderer.MutedText(line))
+
+		childIndent := baseIndent + output.DetailTreePrefix(i == len(nodes)-1)
+		if len(node.children) > 0 {
+			l.renderNodes(childIndent, node.children)
+		}
+		for _, line := range node.outputs {
+			l.renderer.TreeLine(
+				l.renderer.MutedText(childIndent),
+				l.renderer.MutedText(line),
+			)
 		}
 	}
-
-	l.current = nil
-	l.currentLog = nil
 }

--- a/internal/ui/grouped_step_logger.go
+++ b/internal/ui/grouped_step_logger.go
@@ -6,7 +6,6 @@ type groupedStepLogger struct {
 	renderer     *Renderer
 	current      *groupedStep
 	currentGroup *groupedStepNode
-	currentNode  *groupedStepNode
 }
 
 type groupedStep struct {
@@ -15,9 +14,7 @@ type groupedStep struct {
 }
 
 type groupedStepNode struct {
-	title    string
-	outputs  []string
-	children []*groupedStepNode
+	title string
 }
 
 func NewGroupedStepLogger(renderer *Renderer) *groupedStepLogger {
@@ -40,12 +37,10 @@ func (l *groupedStepLogger) BeginGroup(text string) {
 	node := &groupedStepNode{title: text}
 	l.current.nodes = append(l.current.nodes, node)
 	l.currentGroup = node
-	l.currentNode = nil
 }
 
 func (l *groupedStepLogger) EndGroup() {
 	l.currentGroup = nil
-	l.currentNode = nil
 }
 
 func (l *groupedStepLogger) Log(text string) {
@@ -56,24 +51,13 @@ func (l *groupedStepLogger) Log(text string) {
 		l.renderer.StepLog(text)
 		return
 	}
-	node := &groupedStepNode{title: text}
-	if l.currentGroup != nil {
-		l.currentGroup.children = append(l.currentGroup.children, node)
-	} else {
-		l.current.nodes = append(l.current.nodes, node)
+	if l.currentGroup == nil {
+		l.current.nodes = append(l.current.nodes, &groupedStepNode{title: text})
 	}
-	l.currentNode = node
 }
 
 func (l *groupedStepLogger) LogOutput(text string) {
-	if l.renderer == nil {
-		return
-	}
-	if l.current == nil || l.currentNode == nil {
-		l.renderer.StepLogOutput(text)
-		return
-	}
-	l.currentNode.outputs = append(l.currentNode.outputs, text)
+	return
 }
 
 func (l *groupedStepLogger) Flush() {
@@ -82,33 +66,17 @@ func (l *groupedStepLogger) Flush() {
 	}
 
 	l.renderer.Step(l.current.title)
-	l.renderNodes(output.Indent, l.current.nodes)
-
-	l.current = nil
-	l.currentGroup = nil
-	l.currentNode = nil
-}
-
-func (l *groupedStepLogger) renderNodes(baseIndent string, nodes []*groupedStepNode) {
-	for i, node := range nodes {
+	for i, node := range l.current.nodes {
 		prefix := output.TreeBranchMid
-		if i == len(nodes)-1 {
+		if i == len(l.current.nodes)-1 {
 			prefix = output.TreeBranchLast
 		}
 		l.renderer.TreeLine(
-			l.renderer.MutedText(baseIndent+prefix),
+			l.renderer.MutedText(output.Indent+prefix),
 			l.renderer.MutedText(node.title),
 		)
-
-		childIndent := baseIndent + output.DetailTreePrefix(i == len(nodes)-1)
-		if len(node.children) > 0 {
-			l.renderNodes(childIndent, node.children)
-		}
-		for _, line := range node.outputs {
-			l.renderer.TreeLine(
-				l.renderer.MutedText(childIndent),
-				l.renderer.MutedText(line),
-			)
-		}
 	}
+
+	l.current = nil
+	l.currentGroup = nil
 }

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -593,7 +593,7 @@ func (m createFlowModel) View() string {
 			renderPromptValueLine(labelDesc, ""),
 		)
 		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(renderTextInputAssistLines(m.descInput.Value(), m.theme, m.useColor)...)
+		frame.AppendInputsRaw(renderTextInputAssistLines(m.descInput.View(), m.theme, m.useColor)...)
 		return frame.Render()
 	}
 	if m.stage == createStagePresetBranch {
@@ -908,7 +908,7 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 	}
 	if m.stage == stageWorkspace {
 		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(renderTextInputAssistLines(m.idInput.Value(), m.theme, m.useColor)...)
+		frame.AppendInputsRaw(renderTextInputAssistLines(m.idInput.View(), m.theme, m.useColor)...)
 	}
 
 	if m.stage == stageWorkspace && m.errorLine != "" {
@@ -1214,7 +1214,7 @@ func (m inputInlineModel) View() string {
 	}
 	frame.SetInputsPrompt(renderPromptValueLine(label+defaultText, ""))
 	frame.AppendInputsRaw("")
-	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.Value(), m.theme, m.useColor)...)
+	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
 	if strings.TrimSpace(m.errorLine) != "" {
 		errLine := m.errorLine
 		if m.useColor {
@@ -2055,7 +2055,7 @@ func (m branchInputModel) ViewWithHeader(headerLines ...string) string {
 			}
 		}
 		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(renderTextInputAssistLines(m.input.Value(), m.theme, m.useColor)...)
+		frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
 		if m.errorLine != "" {
 			msg := m.errorLine
 			if m.useColor {
@@ -2418,7 +2418,7 @@ func (m presetNameModel) View() string {
 	label := promptLabel(m.theme, m.useColor, "preset name")
 	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
 	frame.AppendInputsRaw("")
-	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.Value(), m.theme, m.useColor)...)
+	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
 	if m.errorLine != "" {
 		msg := m.errorLine
 		if m.useColor {
@@ -3338,10 +3338,9 @@ func renderTextInputAssistLines(value string, theme Theme, useColor bool) []stri
 }
 
 func renderTextInputLine(value string, theme Theme, useColor bool) string {
-	body := strings.TrimSpace(value)
-	line := fmt.Sprintf("%sinput: %s", output.Indent, body)
+	line := fmt.Sprintf("%sinput: %s", output.Indent, value)
 	if useColor {
-		line = theme.Muted.Render(output.Indent+"input: ") + body
+		line = theme.Muted.Render(output.Indent+"input: ") + value
 	}
 	return wrapRawLineToWidth(line, currentWrapWidth())[0]
 }

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -590,8 +590,10 @@ func (m createFlowModel) View() string {
 			modeLine,
 			fmt.Sprintf("%s: %s", labelSelection, m.selectionValue()),
 			fmt.Sprintf("%s: %s", labelWorkspace, m.workspaceID()),
-			fmt.Sprintf("%s: %s", labelDesc, m.descInput.View()),
+			renderPromptValueLine(labelDesc, ""),
 		)
+		frame.AppendInputsRaw("")
+		frame.AppendInputsRaw(renderTextInputAssistLines(m.descInput.Value(), m.theme, m.useColor)...)
 		return frame.Render()
 	}
 	if m.stage == createStagePresetBranch {
@@ -905,7 +907,8 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 		}
 	}
 	if m.stage == stageWorkspace {
-		frame.AppendInputsRaw(renderTextInputValueLine(m.idInput.View(), m.theme, m.useColor))
+		frame.AppendInputsRaw("")
+		frame.AppendInputsRaw(renderTextInputAssistLines(m.idInput.Value(), m.theme, m.useColor)...)
 	}
 
 	if m.stage == stageWorkspace && m.errorLine != "" {
@@ -1209,8 +1212,9 @@ func (m inputInlineModel) View() string {
 	if strings.TrimSpace(m.defaultValue) != "" {
 		defaultText = fmt.Sprintf(" [default: %s]", m.defaultValue)
 	}
-	line := fmt.Sprintf("%s%s: %s", label, defaultText, m.input.View())
-	frame.SetInputsPrompt(line)
+	frame.SetInputsPrompt(renderPromptValueLine(label+defaultText, ""))
+	frame.AppendInputsRaw("")
+	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.Value(), m.theme, m.useColor)...)
 	if strings.TrimSpace(m.errorLine) != "" {
 		errLine := m.errorLine
 		if m.useColor {
@@ -2044,15 +2048,14 @@ func (m branchInputModel) ViewWithHeader(headerLines ...string) string {
 			}
 			frame.AppendInputsPrompt(label)
 
-			value := ""
 			if i < m.index {
-				value = m.selections[i].Branch
-			} else {
-				value = m.input.View()
+				value := m.selections[i].Branch
+				connector := mutedToken(m.theme, m.useColor, output.LogConnector)
+				frame.AppendInputsRaw(fmt.Sprintf("%s%s branch: %s", output.Indent+output.Indent, connector, value))
 			}
-			connector := mutedToken(m.theme, m.useColor, output.LogConnector)
-			frame.AppendInputsRaw(fmt.Sprintf("%s%s branch: %s", output.Indent+output.Indent, connector, value))
 		}
+		frame.AppendInputsRaw("")
+		frame.AppendInputsRaw(renderTextInputAssistLines(m.input.Value(), m.theme, m.useColor)...)
 		if m.errorLine != "" {
 			msg := m.errorLine
 			if m.useColor {
@@ -2413,7 +2416,9 @@ func (m presetNameModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m presetNameModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "preset name")
-	frame.SetInputsPrompt(fmt.Sprintf("%s: %s", label, m.input.View()))
+	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
+	frame.AppendInputsRaw("")
+	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.Value(), m.theme, m.useColor)...)
 	if m.errorLine != "" {
 		msg := m.errorLine
 		if m.useColor {
@@ -3323,6 +3328,30 @@ func selectedInputValue(confirming bool, value string) string {
 
 func renderTextInputValueLine(value string, theme Theme, useColor bool) string {
 	return fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(theme, useColor, output.LogConnector), value)
+}
+
+func renderTextInputAssistLines(value string, theme Theme, useColor bool) []string {
+	return []string{
+		renderTextInputLine(value, theme, useColor),
+		renderTextInputFooterLine(theme, useColor),
+	}
+}
+
+func renderTextInputLine(value string, theme Theme, useColor bool) string {
+	body := strings.TrimSpace(value)
+	line := fmt.Sprintf("%sinput: %s", output.Indent, body)
+	if useColor {
+		line = theme.Muted.Render(output.Indent+"input: ") + body
+	}
+	return wrapRawLineToWidth(line, currentWrapWidth())[0]
+}
+
+func renderTextInputFooterLine(theme Theme, useColor bool) string {
+	line := fmt.Sprintf("%senter confirm  esc cancel", output.Indent)
+	if useColor {
+		line = theme.Muted.Render(line)
+	}
+	return wrapRawLineToWidth(line, currentWrapWidth())[0]
 }
 
 func renderMultiSelectFooterLine(selectedCount int, total int, action string, theme Theme, useColor bool) string {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -2052,10 +2052,17 @@ func (m branchInputModel) ViewWithHeader(headerLines ...string) string {
 				value := m.selections[i].Branch
 				connector := mutedToken(m.theme, m.useColor, output.LogConnector)
 				frame.AppendInputsRaw(fmt.Sprintf("%s%s branch: %s", output.Indent+output.Indent, connector, value))
+				continue
+			}
+			if i == m.index && !m.done {
+				connector := mutedToken(m.theme, m.useColor, output.LogConnector)
+				frame.AppendInputsRaw(fmt.Sprintf("%s%s branch:", output.Indent+output.Indent, connector))
 			}
 		}
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
+		if !m.done {
+			frame.AppendInputsRaw("")
+			frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
+		}
 		if m.errorLine != "" {
 			msg := m.errorLine
 			if m.useColor {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -3372,15 +3372,11 @@ func renderChoiceList(b *strings.Builder, items []string, cursor int, maxVisible
 		if useColor && selected {
 			selectMark = theme.Accent.Render(selectMark)
 		}
-		connector := output.TreeBranchMid
-		if i == len(items)-1 {
-			connector = output.TreeBranchLast
-		}
 		display := item
 		if i == cursor && useColor && !confirming {
 			display = lipgloss.NewStyle().Bold(true).Render(display)
 		}
-		line := fmt.Sprintf("%s%s %s %s %s", output.Indent, focusMark, selectMark, mutedToken(theme, useColor, connector), display)
+		line := fmt.Sprintf("%s%s %s %s", output.Indent, focusMark, selectMark, display)
 		wrapped := wrapRawLineToWidth(line, width)
 		if confirming && !selected && useColor {
 			for i := range wrapped {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -878,7 +878,7 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 
 	if m.stage == stageWorkspace {
 		label := promptLabel(m.theme, m.useColor, "workspace id")
-		promptLines = append(promptLines, fmt.Sprintf("%s: %s", label, m.idInput.View()))
+		promptLines = append(promptLines, renderPromptValueLine(label, ""))
 	} else if strings.TrimSpace(m.workspaceID) != "" {
 		label := promptLabel(m.theme, m.useColor, "workspace id")
 		promptLines = append(promptLines, fmt.Sprintf("%s: %s", label, m.workspaceID))
@@ -903,6 +903,9 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 			frame.AppendInputsRaw("")
 			frame.AppendInputsRaw(assistLines...)
 		}
+	}
+	if m.stage == stageWorkspace {
+		frame.AppendInputsRaw(renderTextInputValueLine(m.idInput.View(), m.theme, m.useColor))
 	}
 
 	if m.stage == stageWorkspace && m.errorLine != "" {
@@ -3316,6 +3319,10 @@ func selectedInputValue(confirming bool, value string) string {
 		return ""
 	}
 	return strings.TrimSpace(value)
+}
+
+func renderTextInputValueLine(value string, theme Theme, useColor bool) string {
+	return fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(theme, useColor, output.LogConnector), value)
 }
 
 func renderMultiSelectFooterLine(selectedCount int, total int, action string, theme Theme, useColor bool) string {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -392,7 +392,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.stage == createStagePreset {
-		model, _ := m.presetModel.Update(msg)
+		model, cmd := m.presetModel.Update(msg)
 		m.presetModel = model.(inputsModel)
 		if m.presetModel.done {
 			repos, err := m.loadPresetRepos(m.presetName())
@@ -407,7 +407,7 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.beginDescriptionStage()
 			return m, nil
 		}
-		return m, nil
+		return m, cmd
 	}
 
 	if m.stage == createStagePresetDesc {
@@ -557,13 +557,13 @@ func (m createFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.stage == createStageRepoWorkspace {
-		model, _ := m.presetModel.Update(msg)
+		model, cmd := m.presetModel.Update(msg)
 		m.presetModel = model.(inputsModel)
 		if m.presetModel.done {
 			m.beginDescriptionStage()
 			return m, nil
 		}
-		return m, nil
+		return m, cmd
 	}
 
 	var cmd tea.Cmd

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -650,7 +650,7 @@ func (m createFlowModel) View() string {
 	frame.SetInputsPrompt(renderPromptValueLine(modeLabel, m.pendingMode))
 	assistLines := []string(nil)
 	if !m.confirming {
-		assistLines = singleSelectAssistLines("select", m.modeInput.Value(), m.theme, m.useColor)
+		assistLines = singleSelectAssistLines("select", m.modeInput.View(), m.theme, m.useColor)
 	}
 	extraAssistGap := 0
 	if len(assistLines) > 0 {
@@ -890,7 +890,7 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 	if m.stage == stagePreset {
 		assistLines := []string(nil)
 		if !m.confirming {
-			assistLines = singleSelectAssistLines("select", m.search.Value(), m.theme, m.useColor)
+			assistLines = singleSelectAssistLines("select", m.search.View(), m.theme, m.useColor)
 		}
 		extraAssistGap := 0
 		if len(assistLines) > 0 {
@@ -1435,7 +1435,7 @@ func (m presetRepoSelectModel) View() string {
 	}
 	assistLines := []string(nil)
 	if m.stage == stageRepoSelect && !m.confirming {
-		assistLines = multiSelectAssistLines(m.selected, len(m.choices), "apply", m.repoInput.Value(), m.theme, m.useColor)
+		assistLines = multiSelectAssistLines(m.selected, len(m.choices), "apply", m.repoInput.View(), m.theme, m.useColor)
 	}
 	extraAssistGap := 0
 	if len(assistLines) > 0 {
@@ -1636,7 +1636,7 @@ func (m choiceSelectModel) ViewWithHeader(headerLines ...string) string {
 	}
 	assistLines := []string(nil)
 	if !m.confirming {
-		assistLines = singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+		assistLines = singleSelectAssistLines("select", m.input.View(), m.theme, m.useColor)
 	}
 	extraAssistGap := 0
 	if len(assistLines) > 0 {
@@ -1881,7 +1881,7 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	}
 	assistLines := []string(nil)
 	if !model.confirming {
-		assistLines = multiSelectAssistLines(model.selectedValues, len(model.choices), "apply", model.input.Value(), model.theme, model.useColor)
+		assistLines = multiSelectAssistLines(model.selectedValues, len(model.choices), "apply", model.input.View(), model.theme, model.useColor)
 	}
 	extraAssistGap := 0
 	if len(assistLines) > 0 {
@@ -2708,7 +2708,7 @@ func (m workspaceSelectModel) ViewWithHeader(headerLines ...string) string {
 	}
 	assistLines := []string(nil)
 	if !m.confirming {
-		assistLines = singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+		assistLines = singleSelectAssistLines("select", m.input.View(), m.theme, m.useColor)
 	}
 	extraAssistGap := 0
 	if len(assistLines) > 0 {
@@ -2845,7 +2845,7 @@ func (m workspaceRepoSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
 	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
-	assistLines := singleSelectAssistLines("select", m.input.Value(), m.theme, m.useColor)
+	assistLines := singleSelectAssistLines("select", m.input.View(), m.theme, m.useColor)
 	maxLines := listMaxLines(m.height, 1+len(assistLines)+1, 0)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceRepoChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
@@ -3216,7 +3216,7 @@ func (m workspaceMultiSelectModel) View() string {
 	}
 	assistLines := []string(nil)
 	if !m.confirming {
-		assistLines = multiSelectAssistLines(m.selectedIDs, len(m.workspaces), "apply", m.input.Value(), m.theme, m.useColor)
+		assistLines = multiSelectAssistLines(m.selectedIDs, len(m.workspaces), "apply", m.input.View(), m.theme, m.useColor)
 	}
 	extraAssistGap := 0
 	if len(assistLines) > 0 {
@@ -3290,23 +3290,22 @@ func listWindow(total int, cursor int, maxVisible int) (int, int) {
 
 func multiSelectAssistLines(selected []string, total int, action string, filterValue string, theme Theme, useColor bool) []string {
 	return []string{
-		renderMultiSelectFilterLine(filterValue, theme, useColor),
+		renderLabeledAssistLine("filter", filterValue, theme, useColor),
 		renderMultiSelectFooterLine(len(selected), total, action, theme, useColor),
 	}
 }
 
 func singleSelectAssistLines(action string, filterValue string, theme Theme, useColor bool) []string {
 	return []string{
-		renderMultiSelectFilterLine(filterValue, theme, useColor),
+		renderLabeledAssistLine("filter", filterValue, theme, useColor),
 		renderSingleSelectFooterLine(action, theme, useColor),
 	}
 }
 
-func renderMultiSelectFilterLine(filterValue string, theme Theme, useColor bool) string {
-	body := strings.TrimSpace(filterValue)
-	line := fmt.Sprintf("%sfilter: %s", output.Indent, body)
+func renderLabeledAssistLine(label, value string, theme Theme, useColor bool) string {
+	line := fmt.Sprintf("%s%s: %s", output.Indent, label, value)
 	if useColor {
-		line = theme.Muted.Render(output.Indent+"filter: ") + body
+		line = theme.Muted.Render(output.Indent+label+": ") + value
 	}
 	return wrapRawLineToWidth(line, currentWrapWidth())[0]
 }
@@ -3332,17 +3331,9 @@ func renderTextInputValueLine(value string, theme Theme, useColor bool) string {
 
 func renderTextInputAssistLines(value string, theme Theme, useColor bool) []string {
 	return []string{
-		renderTextInputLine(value, theme, useColor),
+		renderLabeledAssistLine("input", value, theme, useColor),
 		renderTextInputFooterLine(theme, useColor),
 	}
-}
-
-func renderTextInputLine(value string, theme Theme, useColor bool) string {
-	line := fmt.Sprintf("%sinput: %s", output.Indent, value)
-	if useColor {
-		line = theme.Muted.Render(output.Indent+"input: ") + value
-	}
-	return wrapRawLineToWidth(line, currentWrapWidth())[0]
 }
 
 func renderTextInputFooterLine(theme Theme, useColor bool) string {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1123,16 +1123,12 @@ func (m confirmInlineLineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m confirmInlineLineModel) View() string {
+	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
-	line := fmt.Sprintf("%s (y/n)", label)
-
-	prefix := output.StepPrefix + " "
-	if m.useColor {
-		prefix = m.theme.Accent.Render(output.StepPrefix) + " "
-	}
-	connector := mutedToken(m.theme, m.useColor, output.LogConnector)
-	return output.Indent + prefix + line + "\n" +
-		fmt.Sprintf("%s%s %s\n", output.Indent+output.Indent, connector, m.input.View())
+	frame.SetInputsPrompt(fmt.Sprintf("%s (y/n)", label))
+	frame.AppendInputsRaw("")
+	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
+	return frame.Render()
 }
 
 type inputInlineModel struct {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -88,17 +88,18 @@ type inputsModel struct {
 	label       string
 	validateID  func(string) error
 
-	stage     inputsStage
-	theme     Theme
-	useColor  bool
-	search    textinput.Model
-	idInput   textinput.Model
-	filtered  []string
-	cursor    int
-	err       error
-	errorLine string
-	done      bool
-	height    int
+	stage      inputsStage
+	theme      Theme
+	useColor   bool
+	search     textinput.Model
+	idInput    textinput.Model
+	filtered   []string
+	cursor     int
+	err        error
+	errorLine  string
+	confirming bool
+	done       bool
+	height     int
 }
 
 type createFlowModel struct {
@@ -764,7 +765,21 @@ func (m inputsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		return m, nil
+	case singleSelectConfirmDoneMsg:
+		if m.stage == stagePreset && m.confirming {
+			m.confirming = false
+			if strings.TrimSpace(m.workspaceID) != "" {
+				m.done = true
+				return m, tea.Quit
+			}
+			m.stage = stageWorkspace
+			m.idInput.Focus()
+			return m, nil
+		}
 	case tea.KeyMsg:
+		if m.stage == stagePreset && m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -775,13 +790,9 @@ func (m inputsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				m.preset = m.filtered[m.cursor]
-				if strings.TrimSpace(m.workspaceID) != "" {
-					m.done = true
-					return m, tea.Quit
-				}
-				m.stage = stageWorkspace
-				m.idInput.Focus()
-				return m, nil
+				m.confirming = true
+				m.search.Blur()
+				return m, singleSelectConfirmCmd()
 			}
 			if m.stage == stageWorkspace {
 				value := strings.TrimSpace(m.idInput.Value())
@@ -809,6 +820,25 @@ func (m inputsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cursor++
 				return m, nil
 			}
+		case tea.KeySpace:
+			if m.stage == stagePreset {
+				if len(m.filtered) == 0 {
+					return m, nil
+				}
+				m.preset = m.filtered[m.cursor]
+				m.confirming = true
+				m.search.Blur()
+				return m, singleSelectConfirmCmd()
+			}
+		}
+		if m.stage == stagePreset && msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == ' ' || msg.Runes[0] == '　') {
+			if len(m.filtered) == 0 {
+				return m, nil
+			}
+			m.preset = m.filtered[m.cursor]
+			m.confirming = true
+			m.search.Blur()
+			return m, singleSelectConfirmCmd()
 		}
 	}
 
@@ -841,9 +871,9 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 	labelPreset := promptLabel(m.theme, m.useColor, label)
 	promptLines := append([]string(nil), headerLines...)
 	if m.stage == stagePreset {
-		promptLines = append(promptLines, fmt.Sprintf("%s: %s", labelPreset, m.search.View()))
+		promptLines = append(promptLines, renderPromptValueLine(labelPreset, selectedInputValue(m.confirming, m.preset)))
 	} else {
-		promptLines = append(promptLines, fmt.Sprintf("%s: %s", labelPreset, m.preset))
+		promptLines = append(promptLines, renderPromptValueLine(labelPreset, m.preset))
 	}
 
 	if m.stage == stageWorkspace {
@@ -856,11 +886,23 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 	frame.SetInputsPrompt(promptLines...)
 
 	if m.stage == stagePreset {
-		maxLines := listMaxLines(m.height, len(promptLines), 0)
+		assistLines := []string(nil)
+		if !m.confirming {
+			assistLines = singleSelectAssistLines("select", m.search.Value(), m.theme, m.useColor)
+		}
+		extraAssistGap := 0
+		if len(assistLines) > 0 {
+			extraAssistGap = 1
+		}
+		maxLines := listMaxLines(m.height, len(promptLines)+len(assistLines)+extraAssistGap, 0)
 		rawLines := collectLines(func(b *strings.Builder) {
-			renderChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
+			renderChoiceList(b, m.filtered, m.cursor, maxLines, m.preset, m.confirming, m.useColor, m.theme)
 		})
 		frame.AppendInputsRaw(rawLines...)
+		if len(assistLines) > 0 {
+			frame.AppendInputsRaw("")
+			frame.AppendInputsRaw(assistLines...)
+		}
 	}
 
 	if m.stage == stageWorkspace && m.errorLine != "" {
@@ -1183,6 +1225,7 @@ type presetRepoSelectModel struct {
 	filtered   []PromptChoice
 	selected   []string
 	addedNote  string
+	confirming bool
 
 	theme    Theme
 	useColor bool
@@ -1252,7 +1295,15 @@ func (m presetRepoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		return m, nil
+	case singleSelectConfirmDoneMsg:
+		if m.confirming {
+			return m, tea.Quit
+		}
+		return m, nil
 	case tea.KeyMsg:
+		if m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -1273,7 +1324,9 @@ func (m presetRepoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.errorLine = "select at least one repo"
 				return m, nil
 			}
-			return m, tea.Quit
+			m.confirming = true
+			m.repoInput.Blur()
+			return m, singleSelectConfirmCmd()
 		case tea.KeyUp:
 			if m.cursor > 0 {
 				m.cursor--
@@ -1301,7 +1354,9 @@ func (m presetRepoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.errorLine = "select at least one repo"
 				return m, nil
 			}
-			return m, tea.Quit
+			m.confirming = true
+			m.repoInput.Blur()
+			return m, singleSelectConfirmCmd()
 		case tea.KeySpace:
 			if m.stage == stagePresetName {
 				return m, nil
@@ -1358,26 +1413,39 @@ func (m presetRepoSelectModel) View() string {
 		presetName = m.nameInput.View()
 	}
 	labelRepo := promptLabel(m.theme, m.useColor, "repo")
-	repoInput := m.repoInput.View()
-	if m.stage == stagePresetName {
-		repoInput = ""
+	repoValue := ""
+	if m.stage == stageRepoSelect && m.confirming {
+		repoValue = strings.Join(m.selected, ", ")
 	}
 	frame.SetInputsPrompt(
 		fmt.Sprintf("%s: %s", labelName, presetName),
-		fmt.Sprintf("%s: %s", labelRepo, repoInput),
+		renderPromptValueLine(labelRepo, repoValue),
 	)
 
 	infoLines := 0
 	if m.errorLine != "" {
 		infoLines++
 	}
-	assistLines := multiSelectAssistLines(m.selected, len(m.choices), "apply", m.repoInput.Value(), m.theme, m.useColor)
-	maxLines := listMaxLines(m.height, 2+len(assistLines), infoLines)
+	assistLines := []string(nil)
+	if m.stage == stageRepoSelect && !m.confirming {
+		assistLines = multiSelectAssistLines(m.selected, len(m.choices), "apply", m.repoInput.Value(), m.theme, m.useColor)
+	}
+	extraAssistGap := 0
+	if len(assistLines) > 0 {
+		extraAssistGap = 1
+	}
+	maxLines := listMaxLines(m.height, 2+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
-		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedChoiceSet(m.selected), false, m.useColor, m.theme)
+		if m.stage == stagePresetName {
+			return
+		}
+		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedChoiceSet(m.selected), m.confirming, m.useColor, m.theme)
 	})
 	frame.AppendInputsRaw(rawLines...)
-	frame.AppendInputsRaw(assistLines...)
+	if len(assistLines) > 0 {
+		frame.AppendInputsRaw("")
+		frame.AppendInputsRaw(assistLines...)
+	}
 
 	if m.errorLine != "" {
 		msg := m.errorLine
@@ -3243,6 +3311,13 @@ func renderPromptValueLine(label, value string) string {
 	return fmt.Sprintf("%s: %s", label, value)
 }
 
+func selectedInputValue(confirming bool, value string) string {
+	if !confirming {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
 func renderMultiSelectFooterLine(selectedCount int, total int, action string, theme Theme, useColor bool) string {
 	if total < selectedCount {
 		total = selectedCount
@@ -3268,7 +3343,7 @@ func renderSingleSelectFooterLine(action string, theme Theme, useColor bool) str
 	return wrapRawLineToWidth(line, currentWrapWidth())[0]
 }
 
-func renderChoiceList(b *strings.Builder, items []string, cursor int, maxVisible int, useColor bool, theme Theme) {
+func renderChoiceList(b *strings.Builder, items []string, cursor int, maxVisible int, selectedValue string, confirming bool, useColor bool, theme Theme) {
 	if maxVisible <= 0 {
 		return
 	}
@@ -3285,12 +3360,34 @@ func renderChoiceList(b *strings.Builder, items []string, cursor int, maxVisible
 	groups := make([]workspaceRepoChoiceGroup, 0, len(items))
 	for i := range items {
 		item := items[i]
+		focusMark := " "
+		if i == cursor {
+			focusMark = ">"
+		}
+		selected := item == selectedValue
+		selectMark := "○"
+		if selected {
+			selectMark = "●"
+		}
+		if useColor && selected {
+			selectMark = theme.Accent.Render(selectMark)
+		}
+		connector := output.TreeBranchMid
+		if i == len(items)-1 {
+			connector = output.TreeBranchLast
+		}
 		display := item
-		if i == cursor && useColor {
+		if i == cursor && useColor && !confirming {
 			display = lipgloss.NewStyle().Bold(true).Render(display)
 		}
-		line := fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(theme, useColor, output.LogConnector), display)
-		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapRawLineToWidth(line, width)})
+		line := fmt.Sprintf("%s%s %s %s %s", output.Indent, focusMark, selectMark, mutedToken(theme, useColor, connector), display)
+		wrapped := wrapRawLineToWidth(line, width)
+		if confirming && !selected && useColor {
+			for i := range wrapped {
+				wrapped[i] = theme.Muted.Render(ansi.Strip(wrapped[i]))
+			}
+		}
+		groups = append(groups, workspaceRepoChoiceGroup{lines: wrapped})
 	}
 
 	if cursor < 0 || cursor >= len(groups) {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -591,6 +591,7 @@ func (m createFlowModel) View() string {
 			fmt.Sprintf("%s: %s", labelSelection, m.selectionValue()),
 			fmt.Sprintf("%s: %s", labelWorkspace, m.workspaceID()),
 		)
+		frame.AppendContextRaw(renderPendingContextValueLine(labelDesc, m.theme, m.useColor))
 		frame.SetStepPrompt(renderPromptValueLine(labelDesc, ""))
 		frame.AppendStepRaw("")
 		frame.AppendStepRaw(renderTextInputAssistLines(m.descInput.View(), m.theme, m.useColor)...)
@@ -647,6 +648,7 @@ func (m createFlowModel) View() string {
 	}
 
 	frame := NewFrame(m.theme, m.useColor)
+	frame.SetContextRaw(renderPendingContextValueLine(modeLabel, m.theme, m.useColor))
 	frame.SetStepPrompt(renderPromptValueLine(modeLabel, m.pendingMode))
 	assistLines := []string(nil)
 	if !m.confirming {
@@ -656,7 +658,7 @@ func (m createFlowModel) View() string {
 	if len(assistLines) > 0 {
 		extraAssistGap = 1
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, 0)
+	maxLines := listMaxLines(m.height, 1, 1+len(assistLines)+extraAssistGap, 0)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.pendingMode, m.confirming, m.useColor, m.theme)
 	})
@@ -874,6 +876,7 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 	promptLines := append([]string(nil), headerLines...)
 	if m.stage == stagePreset {
 		frame.SetContextPrompt(promptLines...)
+		frame.AppendContextRaw(renderPendingContextValueLine(labelPreset, m.theme, m.useColor))
 		frame.SetStepPrompt(renderPromptValueLine(labelPreset, selectedInputValue(m.confirming, m.preset)))
 	} else {
 		promptLines = append(promptLines, renderPromptValueLine(labelPreset, m.preset))
@@ -882,6 +885,7 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 
 	if m.stage == stageWorkspace {
 		label := promptLabel(m.theme, m.useColor, "workspace id")
+		frame.AppendContextRaw(renderPendingContextValueLine(label, m.theme, m.useColor))
 		frame.SetStepPrompt(renderPromptValueLine(label, ""))
 	} else if strings.TrimSpace(m.workspaceID) != "" {
 		label := promptLabel(m.theme, m.useColor, "workspace id")
@@ -897,7 +901,8 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 		if len(assistLines) > 0 {
 			extraAssistGap = 1
 		}
-		maxLines := listMaxLines(m.height, len(promptLines)+len(assistLines)+extraAssistGap, 0)
+		contextLines := len(promptLines) + 1
+		maxLines := listMaxLines(m.height, contextLines, 1+len(assistLines)+extraAssistGap, 0)
 		rawLines := collectLines(func(b *strings.Builder) {
 			renderChoiceList(b, m.filtered, m.cursor, maxLines, m.preset, m.confirming, m.useColor, m.theme)
 		})
@@ -977,13 +982,14 @@ type confirmInlineModel struct {
 // confirmInlineLineModel renders a single inline prompt line (no Frame/section headers).
 // Intended for embedding prompts inside an existing section (e.g. Plan).
 type confirmInlineLineModel struct {
-	label    string
-	theme    Theme
-	useColor bool
-	input    textinput.Model
-	value    bool
-	err      error
-	done     bool
+	label      string
+	theme      Theme
+	useColor   bool
+	input      textinput.Model
+	value      bool
+	err        error
+	done       bool
+	confirming bool
 }
 
 func newConfirmInlineModel(label string, theme Theme, useColor bool, useInfo bool, inputsPrompt []string, inputsRaw []string) confirmInlineModel {
@@ -1093,7 +1099,16 @@ func (m confirmInlineLineModel) Init() tea.Cmd {
 
 func (m confirmInlineLineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case singleSelectConfirmDoneMsg:
+		if m.confirming {
+			m.done = true
+			return m, tea.Quit
+		}
+		return m, nil
 	case tea.KeyMsg:
+		if m.confirming {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.err = ErrPromptCanceled
@@ -1103,12 +1118,14 @@ func (m confirmInlineLineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch value {
 			case "y", "yes":
 				m.value = true
-				m.done = true
-				return m, tea.Quit
+				m.confirming = true
+				m.input.Blur()
+				return m, singleSelectConfirmCmd()
 			case "n", "no":
 				m.value = false
-				m.done = true
-				return m, tea.Quit
+				m.confirming = true
+				m.input.Blur()
+				return m, singleSelectConfirmCmd()
 			default:
 				return m, nil
 			}
@@ -1120,6 +1137,9 @@ func (m confirmInlineLineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m confirmInlineLineModel) View() string {
+	if m.confirming {
+		return ""
+	}
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
 	frame.SetStepPrompt(fmt.Sprintf("%s (y/n)", label))
@@ -1201,6 +1221,7 @@ func (m inputInlineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m inputInlineModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
+	frame.SetContextRaw(renderPendingContextValueLine(label, m.theme, m.useColor))
 	defaultText := ""
 	if strings.TrimSpace(m.defaultValue) != "" {
 		defaultText = fmt.Sprintf(" [default: %s]", m.defaultValue)
@@ -1416,8 +1437,10 @@ func (m presetRepoSelectModel) View() string {
 	}
 	if m.stage == stageRepoSelect {
 		frame.SetContextPrompt(fmt.Sprintf("%s: %s", labelName, presetName))
+		frame.AppendContextRaw(renderPendingContextValueLine(labelRepo, m.theme, m.useColor))
 		frame.SetStepPrompt(renderPromptValueLine(labelRepo, repoValue))
 	} else {
+		frame.SetContextRaw(renderPendingContextValueLine(labelName, m.theme, m.useColor))
 		frame.SetStepPrompt(renderPromptValueLine(labelName, ""))
 	}
 
@@ -1433,7 +1456,11 @@ func (m presetRepoSelectModel) View() string {
 	if len(assistLines) > 0 {
 		extraAssistGap = 1
 	}
-	maxLines := listMaxLines(m.height, 2+len(assistLines)+extraAssistGap, infoLines)
+	contextLines := 1
+	if m.stage == stageRepoSelect {
+		contextLines = 2
+	}
+	maxLines := listMaxLines(m.height, contextLines, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		if m.stage == stagePresetName {
 			return
@@ -1623,6 +1650,7 @@ func (m choiceSelectModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
 	frame.SetContextPrompt(headerLines...)
+	frame.AppendContextRaw(renderPendingContextValueLine(label, m.theme, m.useColor))
 	frame.SetStepPrompt(renderPromptValueLine(label, m.value))
 
 	infoLines := 0
@@ -1637,7 +1665,7 @@ func (m choiceSelectModel) ViewWithHeader(headerLines ...string) string {
 	if len(assistLines) > 0 {
 		extraAssistGap = 1
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, infoLines)
+	maxLines := listMaxLines(m.height, len(headerLines)+1, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.value, m.confirming, m.useColor, m.theme)
 	})
@@ -1866,6 +1894,7 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	frame := NewFrame(model.theme, model.useColor)
 	label := promptLabel(model.theme, model.useColor, model.label)
 	frame.SetContextPrompt(headerLines...)
+	frame.AppendContextRaw(renderPendingContextValueLine(label, model.theme, model.useColor))
 	frame.SetStepPrompt(renderPromptValueLine(label, ""))
 
 	hasError := model.errorLine != ""
@@ -1881,7 +1910,7 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	if len(assistLines) > 0 {
 		extraAssistGap = 1
 	}
-	maxLines := listMaxLines(height, len(headerLines)+1+len(assistLines)+extraAssistGap, infoLines)
+	maxLines := listMaxLines(height, len(headerLines)+1, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoMultiSelectChoiceList(b, model.filtered, model.cursor, maxLines, selectedChoiceSet(model.selectedValues), model.confirming, model.useColor, model.theme)
 	})
@@ -2421,6 +2450,7 @@ func (m presetNameModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m presetNameModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "preset name")
+	frame.SetContextRaw(renderPendingContextValueLine(label, m.theme, m.useColor))
 	frame.SetStepPrompt(renderPromptValueLine(label, ""))
 	frame.AppendStepRaw("")
 	frame.AppendStepRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
@@ -2564,16 +2594,25 @@ func max(a, b int) int {
 
 const defaultViewportHeight = 20
 
-func listMaxLines(height int, inputLines int, infoLines int) int {
+func listMaxLines(height int, contextLines int, stepLines int, infoLines int) int {
 	if height <= 0 {
 		height = defaultViewportHeight
 	}
 	total := 0
-	if inputLines > 0 {
-		total += 1 + inputLines + 1
+	if contextLines > 0 {
+		total += 1 + contextLines
+		if stepLines > 0 || infoLines > 0 {
+			total++
+		}
+	}
+	if stepLines > 0 {
+		total += 1 + stepLines
+		if infoLines > 0 {
+			total++
+		}
 	}
 	if infoLines > 0 {
-		total += 1 + infoLines + 1
+		total += 1 + infoLines
 	}
 	maxLines := height - total
 	if maxLines < 0 {
@@ -2701,6 +2740,7 @@ func (m workspaceSelectModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace id")
 	frame.SetContextPrompt(headerLines...)
+	frame.AppendContextRaw(renderPendingContextValueLine(label, m.theme, m.useColor))
 	frame.SetStepPrompt(renderPromptValueLine(label, m.workspaceID))
 	var blockedLines []string
 	infoLines := 0
@@ -2718,7 +2758,7 @@ func (m workspaceSelectModel) ViewWithHeader(headerLines ...string) string {
 	if len(assistLines) > 0 {
 		extraAssistGap = 1
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, infoLines)
+	maxLines := listMaxLines(m.height, len(headerLines)+1, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.workspaceID, m.confirming, m.useColor, m.theme)
 	})
@@ -2848,9 +2888,10 @@ func (m workspaceRepoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceRepoSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
+	frame.SetContextRaw(renderPendingContextValueLine(label, m.theme, m.useColor))
 	frame.SetStepPrompt(renderPromptValueLine(label, ""))
 	assistLines := singleSelectAssistLines("select", m.input.View(), m.theme, m.useColor)
-	maxLines := listMaxLines(m.height, 1+len(assistLines)+1, 0)
+	maxLines := listMaxLines(m.height, 1, 1+len(assistLines)+1, 0)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceRepoChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
 	})
@@ -3206,6 +3247,7 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceMultiSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
+	frame.SetContextRaw(renderPendingContextValueLine(label, m.theme, m.useColor))
 	frame.SetStepPrompt(renderPromptValueLine(label, ""))
 	var blockedLines []string
 	infoLines := 0
@@ -3226,7 +3268,7 @@ func (m workspaceMultiSelectModel) View() string {
 	if len(assistLines) > 0 {
 		extraAssistGap = 1
 	}
-	maxLines := listMaxLines(m.height, 1+len(assistLines)+extraAssistGap, infoLines)
+	maxLines := listMaxLines(m.height, 1, 1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedWorkspaceSet(m.selectedIDs), m.confirming, m.useColor, m.theme)
 	})
@@ -3320,6 +3362,20 @@ func renderPromptValueLine(label, value string) string {
 		return fmt.Sprintf("%s:", label)
 	}
 	return fmt.Sprintf("%s: %s", label, value)
+}
+
+func renderPendingContextValueLine(label string, theme Theme, useColor bool) string {
+	plainLabel := strings.TrimSpace(ansi.Strip(label))
+	if plainLabel == "" {
+		plainLabel = strings.TrimSpace(label)
+	}
+	line := fmt.Sprintf("%s: ", plainLabel)
+	prefix := output.StepPrefix + " "
+	if useColor {
+		prefix = theme.Muted.Render(prefix)
+		line = theme.Muted.Render(line)
+	}
+	return output.Indent + prefix + line
 }
 
 func selectedInputValue(confirming bool, value string) string {

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -586,14 +586,14 @@ func (m createFlowModel) View() string {
 		labelSelection := promptLabel(m.theme, m.useColor, m.selectionLabel())
 		labelWorkspace := promptLabel(m.theme, m.useColor, "workspace id")
 		labelDesc := promptLabel(m.theme, m.useColor, "description")
-		frame.SetInputsPrompt(
+		frame.SetContextPrompt(
 			modeLine,
 			fmt.Sprintf("%s: %s", labelSelection, m.selectionValue()),
 			fmt.Sprintf("%s: %s", labelWorkspace, m.workspaceID()),
-			renderPromptValueLine(labelDesc, ""),
 		)
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(renderTextInputAssistLines(m.descInput.View(), m.theme, m.useColor)...)
+		frame.SetStepPrompt(renderPromptValueLine(labelDesc, ""))
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(renderTextInputAssistLines(m.descInput.View(), m.theme, m.useColor)...)
 		return frame.Render()
 	}
 	if m.stage == createStagePresetBranch {
@@ -647,7 +647,7 @@ func (m createFlowModel) View() string {
 	}
 
 	frame := NewFrame(m.theme, m.useColor)
-	frame.SetInputsPrompt(renderPromptValueLine(modeLabel, m.pendingMode))
+	frame.SetStepPrompt(renderPromptValueLine(modeLabel, m.pendingMode))
 	assistLines := []string(nil)
 	if !m.confirming {
 		assistLines = singleSelectAssistLines("select", m.modeInput.View(), m.theme, m.useColor)
@@ -660,10 +660,10 @@ func (m createFlowModel) View() string {
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.pendingMode, m.confirming, m.useColor, m.theme)
 	})
-	frame.AppendInputsRaw(rawLines...)
+	frame.AppendStepRaw(rawLines...)
 	if len(assistLines) > 0 {
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(assistLines...)
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(assistLines...)
 	}
 	return frame.Render()
 }
@@ -873,19 +873,20 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 	labelPreset := promptLabel(m.theme, m.useColor, label)
 	promptLines := append([]string(nil), headerLines...)
 	if m.stage == stagePreset {
-		promptLines = append(promptLines, renderPromptValueLine(labelPreset, selectedInputValue(m.confirming, m.preset)))
+		frame.SetContextPrompt(promptLines...)
+		frame.SetStepPrompt(renderPromptValueLine(labelPreset, selectedInputValue(m.confirming, m.preset)))
 	} else {
 		promptLines = append(promptLines, renderPromptValueLine(labelPreset, m.preset))
+		frame.SetContextPrompt(promptLines...)
 	}
 
 	if m.stage == stageWorkspace {
 		label := promptLabel(m.theme, m.useColor, "workspace id")
-		promptLines = append(promptLines, renderPromptValueLine(label, ""))
+		frame.SetStepPrompt(renderPromptValueLine(label, ""))
 	} else if strings.TrimSpace(m.workspaceID) != "" {
 		label := promptLabel(m.theme, m.useColor, "workspace id")
-		promptLines = append(promptLines, fmt.Sprintf("%s: %s", label, m.workspaceID))
+		frame.AppendContextPrompt(fmt.Sprintf("%s: %s", label, m.workspaceID))
 	}
-	frame.SetInputsPrompt(promptLines...)
 
 	if m.stage == stagePreset {
 		assistLines := []string(nil)
@@ -900,15 +901,15 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 		rawLines := collectLines(func(b *strings.Builder) {
 			renderChoiceList(b, m.filtered, m.cursor, maxLines, m.preset, m.confirming, m.useColor, m.theme)
 		})
-		frame.AppendInputsRaw(rawLines...)
+		frame.AppendStepRaw(rawLines...)
 		if len(assistLines) > 0 {
-			frame.AppendInputsRaw("")
-			frame.AppendInputsRaw(assistLines...)
+			frame.AppendStepRaw("")
+			frame.AppendStepRaw(assistLines...)
 		}
 	}
 	if m.stage == stageWorkspace {
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(renderTextInputAssistLines(m.idInput.View(), m.theme, m.useColor)...)
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(renderTextInputAssistLines(m.idInput.View(), m.theme, m.useColor)...)
 	}
 
 	if m.stage == stageWorkspace && m.errorLine != "" {
@@ -916,7 +917,7 @@ func (m inputsModel) ViewWithHeader(headerLines ...string) string {
 		if m.useColor {
 			msg = m.theme.Error.Render(msg)
 		}
-		frame.AppendInputsRaw(fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), msg))
+		frame.AppendStepRaw(fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), msg))
 	}
 
 	return frame.Render()
@@ -1066,26 +1067,22 @@ func (m confirmInlineModel) View() string {
 	if m.useInfo {
 		frame.SetInfoPrompt(line)
 	} else if m.rawAfter {
-		frame.SetInputsPrompt(line)
+		frame.SetStepPrompt(line)
 		if len(m.inputsRaw) > 0 {
-			frame.AppendInputsRaw(m.inputsRaw...)
+			frame.AppendStepRaw(m.inputsRaw...)
 		}
 	} else {
 		if len(m.inputsPrompt) > 0 {
-			frame.SetInputsPrompt(m.inputsPrompt...)
+			frame.SetContextPrompt(m.inputsPrompt...)
 		}
 		if len(m.inputsRaw) > 0 {
-			if len(frame.Inputs) == 0 {
-				frame.SetInputsRaw(m.inputsRaw...)
+			if len(frame.Context) == 0 {
+				frame.SetContextRaw(m.inputsRaw...)
 			} else {
-				frame.AppendInputsRaw(m.inputsRaw...)
+				frame.AppendContextRaw(m.inputsRaw...)
 			}
 		}
-		if len(m.inputsPrompt) == 0 && len(m.inputsRaw) == 0 {
-			frame.SetInputsPrompt(line)
-		} else {
-			frame.AppendInputsPrompt(line)
-		}
+		frame.SetStepPrompt(line)
 	}
 	return frame.Render()
 }
@@ -1125,9 +1122,9 @@ func (m confirmInlineLineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m confirmInlineLineModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
-	frame.SetInputsPrompt(fmt.Sprintf("%s (y/n)", label))
-	frame.AppendInputsRaw("")
-	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
+	frame.SetStepPrompt(fmt.Sprintf("%s (y/n)", label))
+	frame.AppendStepRaw("")
+	frame.AppendStepRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
 	return frame.Render()
 }
 
@@ -1208,15 +1205,15 @@ func (m inputInlineModel) View() string {
 	if strings.TrimSpace(m.defaultValue) != "" {
 		defaultText = fmt.Sprintf(" [default: %s]", m.defaultValue)
 	}
-	frame.SetInputsPrompt(renderPromptValueLine(label+defaultText, ""))
-	frame.AppendInputsRaw("")
-	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
+	frame.SetStepPrompt(renderPromptValueLine(label+defaultText, ""))
+	frame.AppendStepRaw("")
+	frame.AppendStepRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
 	if strings.TrimSpace(m.errorLine) != "" {
 		errLine := m.errorLine
 		if m.useColor {
 			errLine = m.theme.Error.Render(errLine)
 		}
-		frame.AppendInputsRaw(fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), errLine))
+		frame.AppendStepRaw(fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), errLine))
 	}
 	return frame.Render()
 }
@@ -1412,18 +1409,17 @@ func (m presetRepoSelectModel) View() string {
 
 	labelName := promptLabel(m.theme, m.useColor, "preset name")
 	presetName := m.presetName
-	if m.stage == stagePresetName {
-		presetName = m.nameInput.View()
-	}
 	labelRepo := promptLabel(m.theme, m.useColor, "repo")
 	repoValue := ""
 	if m.stage == stageRepoSelect && m.confirming {
 		repoValue = strings.Join(m.selected, ", ")
 	}
-	frame.SetInputsPrompt(
-		fmt.Sprintf("%s: %s", labelName, presetName),
-		renderPromptValueLine(labelRepo, repoValue),
-	)
+	if m.stage == stageRepoSelect {
+		frame.SetContextPrompt(fmt.Sprintf("%s: %s", labelName, presetName))
+		frame.SetStepPrompt(renderPromptValueLine(labelRepo, repoValue))
+	} else {
+		frame.SetStepPrompt(renderPromptValueLine(labelName, ""))
+	}
 
 	infoLines := 0
 	if m.errorLine != "" {
@@ -1444,10 +1440,14 @@ func (m presetRepoSelectModel) View() string {
 		}
 		renderRepoMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedChoiceSet(m.selected), m.confirming, m.useColor, m.theme)
 	})
-	frame.AppendInputsRaw(rawLines...)
+	frame.AppendStepRaw(rawLines...)
 	if len(assistLines) > 0 {
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(assistLines...)
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(assistLines...)
+	}
+	if m.stage == stagePresetName {
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(renderTextInputAssistLines(m.nameInput.View(), m.theme, m.useColor)...)
 	}
 
 	if m.errorLine != "" {
@@ -1622,9 +1622,8 @@ func (m choiceSelectModel) View() string {
 func (m choiceSelectModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, m.label)
-	promptLines := append([]string(nil), headerLines...)
-	promptLines = append(promptLines, renderPromptValueLine(label, m.value))
-	frame.SetInputsPrompt(promptLines...)
+	frame.SetContextPrompt(headerLines...)
+	frame.SetStepPrompt(renderPromptValueLine(label, m.value))
 
 	infoLines := 0
 	if m.errorLine != "" {
@@ -1642,10 +1641,10 @@ func (m choiceSelectModel) ViewWithHeader(headerLines ...string) string {
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.value, m.confirming, m.useColor, m.theme)
 	})
-	frame.AppendInputsRaw(rawLines...)
+	frame.AppendStepRaw(rawLines...)
 	if len(assistLines) > 0 {
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(assistLines...)
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(assistLines...)
 	}
 
 	if m.errorLine != "" {
@@ -1865,10 +1864,9 @@ func (m multiSelectModel) View() string {
 
 func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...string) string {
 	frame := NewFrame(model.theme, model.useColor)
-	lines := append([]string(nil), headerLines...)
 	label := promptLabel(model.theme, model.useColor, model.label)
-	lines = append(lines, renderPromptValueLine(label, ""))
-	frame.SetInputsPrompt(lines...)
+	frame.SetContextPrompt(headerLines...)
+	frame.SetStepPrompt(renderPromptValueLine(label, ""))
 
 	hasError := model.errorLine != ""
 	infoLines := 0
@@ -1883,14 +1881,14 @@ func renderMultiSelectFrame(model multiSelectModel, height int, headerLines ...s
 	if len(assistLines) > 0 {
 		extraAssistGap = 1
 	}
-	maxLines := listMaxLines(height, len(lines)+len(assistLines)+extraAssistGap, infoLines)
+	maxLines := listMaxLines(height, len(headerLines)+1+len(assistLines)+extraAssistGap, infoLines)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderRepoMultiSelectChoiceList(b, model.filtered, model.cursor, maxLines, selectedChoiceSet(model.selectedValues), model.confirming, model.useColor, model.theme)
 	})
-	frame.AppendInputsRaw(rawLines...)
+	frame.AppendStepRaw(rawLines...)
 	if len(assistLines) > 0 {
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(assistLines...)
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(assistLines...)
 	}
 
 	if hasError {
@@ -2024,12 +2022,12 @@ func (m branchInputModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	lines := append([]string(nil), headerLines...)
 	if len(m.items) == 0 {
-		frame.SetInputsPrompt(lines...)
+		frame.SetContextPrompt(lines...)
 		return frame.Render()
 	}
 
 	if m.separateInputLine {
-		frame.SetInputsPrompt(lines...)
+		frame.SetContextPrompt(lines...)
 		maxIndex := m.index
 		if maxIndex > len(m.items)-1 {
 			maxIndex = len(m.items) - 1
@@ -2042,22 +2040,26 @@ func (m branchInputModel) ViewWithHeader(headerLines ...string) string {
 			} else if strings.TrimSpace(item.Label) != "" {
 				label = item.Label
 			}
-			frame.AppendInputsPrompt(label)
+			if i < m.index {
+				frame.AppendContextPrompt(label)
+			} else {
+				frame.SetStepPrompt(label)
+			}
 
 			if i < m.index {
 				value := m.selections[i].Branch
 				connector := mutedToken(m.theme, m.useColor, output.LogConnector)
-				frame.AppendInputsRaw(fmt.Sprintf("%s%s branch: %s", output.Indent+output.Indent, connector, value))
+				frame.AppendContextRaw(fmt.Sprintf("%s%s branch: %s", output.Indent+output.Indent, connector, value))
 				continue
 			}
 			if i == m.index && !m.done {
 				connector := mutedToken(m.theme, m.useColor, output.LogConnector)
-				frame.AppendInputsRaw(fmt.Sprintf("%s%s branch:", output.Indent+output.Indent, connector))
+				frame.AppendStepRaw(fmt.Sprintf("%s%s branch:", output.Indent+output.Indent, connector))
 			}
 		}
 		if !m.done {
-			frame.AppendInputsRaw("")
-			frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
+			frame.AppendStepRaw("")
+			frame.AppendStepRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
 		}
 		if m.errorLine != "" {
 			msg := m.errorLine
@@ -2088,7 +2090,7 @@ func (m branchInputModel) ViewWithHeader(headerLines ...string) string {
 			lines = append(lines, fmt.Sprintf("%s: %s", labelBranch, m.input.View()))
 		}
 	}
-	frame.SetInputsPrompt(lines...)
+	frame.SetContextPrompt(lines...)
 	if m.errorLine != "" {
 		msg := m.errorLine
 		if m.useColor {
@@ -2419,15 +2421,15 @@ func (m presetNameModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m presetNameModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "preset name")
-	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
-	frame.AppendInputsRaw("")
-	frame.AppendInputsRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
+	frame.SetStepPrompt(renderPromptValueLine(label, ""))
+	frame.AppendStepRaw("")
+	frame.AppendStepRaw(renderTextInputAssistLines(m.input.View(), m.theme, m.useColor)...)
 	if m.errorLine != "" {
 		msg := m.errorLine
 		if m.useColor {
 			msg = m.theme.Error.Render(msg)
 		}
-		frame.AppendInputsRaw(fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), msg))
+		frame.AppendStepRaw(fmt.Sprintf("%s%s %s", output.Indent+output.Indent, mutedToken(m.theme, m.useColor, output.LogConnector), msg))
 	}
 	return frame.Render()
 }
@@ -2698,9 +2700,8 @@ func (m workspaceSelectModel) View() string {
 func (m workspaceSelectModel) ViewWithHeader(headerLines ...string) string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace id")
-	promptLines := append([]string(nil), headerLines...)
-	promptLines = append(promptLines, renderPromptValueLine(label, m.workspaceID))
-	frame.SetInputsPrompt(promptLines...)
+	frame.SetContextPrompt(headerLines...)
+	frame.SetStepPrompt(renderPromptValueLine(label, m.workspaceID))
 	var blockedLines []string
 	infoLines := 0
 	if len(m.blocked) > 0 {
@@ -2721,10 +2722,10 @@ func (m workspaceSelectModel) ViewWithHeader(headerLines ...string) string {
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceSingleSelectChoiceList(b, m.filtered, m.cursor, maxLines, m.workspaceID, m.confirming, m.useColor, m.theme)
 	})
-	frame.AppendInputsRaw(rawLines...)
+	frame.AppendStepRaw(rawLines...)
 	if len(assistLines) > 0 {
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(assistLines...)
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(assistLines...)
 	}
 	if len(m.blocked) > 0 {
 		frame.SetInfo("blocked workspaces")
@@ -2847,15 +2848,15 @@ func (m workspaceRepoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceRepoSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
-	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
+	frame.SetStepPrompt(renderPromptValueLine(label, ""))
 	assistLines := singleSelectAssistLines("select", m.input.View(), m.theme, m.useColor)
 	maxLines := listMaxLines(m.height, 1+len(assistLines)+1, 0)
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceRepoChoiceList(b, m.filtered, m.cursor, maxLines, m.useColor, m.theme)
 	})
-	frame.AppendInputsRaw(rawLines...)
-	frame.AppendInputsRaw("")
-	frame.AppendInputsRaw(assistLines...)
+	frame.AppendStepRaw(rawLines...)
+	frame.AppendStepRaw("")
+	frame.AppendStepRaw(assistLines...)
 	return frame.Render()
 }
 
@@ -3205,7 +3206,7 @@ func (m workspaceMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m workspaceMultiSelectModel) View() string {
 	frame := NewFrame(m.theme, m.useColor)
 	label := promptLabel(m.theme, m.useColor, "workspace")
-	frame.SetInputsPrompt(renderPromptValueLine(label, ""))
+	frame.SetStepPrompt(renderPromptValueLine(label, ""))
 	var blockedLines []string
 	infoLines := 0
 	if m.errorLine != "" {
@@ -3229,10 +3230,10 @@ func (m workspaceMultiSelectModel) View() string {
 	rawLines := collectLines(func(b *strings.Builder) {
 		renderWorkspaceMultiSelectChoiceList(b, m.filtered, m.cursor, maxLines, selectedWorkspaceSet(m.selectedIDs), m.confirming, m.useColor, m.theme)
 	})
-	frame.AppendInputsRaw(rawLines...)
+	frame.AppendStepRaw(rawLines...)
 	if len(assistLines) > 0 {
-		frame.AppendInputsRaw("")
-		frame.AppendInputsRaw(assistLines...)
+		frame.AppendStepRaw("")
+		frame.AppendStepRaw(assistLines...)
 	}
 
 	if m.errorLine != "" {

--- a/internal/ui/prompt_api.go
+++ b/internal/ui/prompt_api.go
@@ -316,7 +316,7 @@ func PromptCreateFlow(title string, startMode string, defaultWorkspaceID string,
 func WorkspaceChoiceLines(items []WorkspaceChoice, cursor int, useColor bool, theme Theme) []string {
 	var lines []string
 	builder := &strings.Builder{}
-	renderWorkspaceChoiceList(builder, items, cursor, listMaxLines(0, len(items), 0), useColor, theme)
+	renderWorkspaceChoiceList(builder, items, cursor, len(items), useColor, theme)
 	lines = append(lines, splitLines(builder.String())...)
 	return lines
 }

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -825,7 +825,7 @@ func TestBranchInputModel_SeparateInputLine_HidesInputAfterDone(t *testing.T) {
 }
 
 func TestConfirmInlineLineModel_IsMultiline(t *testing.T) {
-	setWrapWidth(20)
+	setWrapWidth(40)
 	defer setWrapWidth(0)
 	setStableLayout(true)
 	defer setStableLayout(false)
@@ -835,8 +835,11 @@ func TestConfirmInlineLineModel_IsMultiline(t *testing.T) {
 	if strings.Count(out, "\n") < 2 {
 		t.Fatalf("expected multiline output, got: %q", out)
 	}
-	if !strings.Contains(out, output.LogConnector) {
-		t.Fatalf("expected output to contain connector")
+	if !strings.Contains(out, "input:") {
+		t.Fatalf("expected output to contain input line")
+	}
+	if !strings.Contains(out, "enter confirm  esc cancel") {
+		t.Fatalf("expected output to contain text input footer")
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -788,11 +788,39 @@ func TestBranchInputModel_SeparateInputLineKeepsBranchVisible(t *testing.T) {
 	model.separateInputLine = true
 
 	out := model.ViewWithHeader("repo: git@github.com:tasuku43/gion.git")
+	if !strings.Contains(out, "branch:") {
+		t.Fatalf("expected output to contain branch context line")
+	}
 	if !strings.Contains(out, "input: issue/96") {
 		t.Fatalf("expected output to contain bottom input line")
 	}
 	if !strings.Contains(out, "enter confirm  esc cancel") {
 		t.Fatalf("expected output to contain text input footer")
+	}
+}
+
+func TestBranchInputModel_SeparateInputLine_HidesInputAfterDone(t *testing.T) {
+	model := newBranchInputModel(
+		"title",
+		[]PromptChoice{{Label: "repo #1 (git@github.com:tasuku43/gion.git)", Value: "repo1"}},
+		func(index int, choice PromptChoice) string { return choice.Label },
+		func(choice PromptChoice) string { return "test" },
+		nil,
+		false,
+		DefaultTheme(),
+		false,
+	)
+	model.separateInputLine = true
+	model.selections[0] = BranchSelection{Value: "repo1", Label: "repo #1 (git@github.com:tasuku43/gion.git)", Branch: "test"}
+	model.index = 1
+	model.done = true
+
+	out := model.View()
+	if strings.Contains(out, "input:") {
+		t.Fatalf("expected bottom input line to be hidden after completion, got: %q", out)
+	}
+	if !strings.Contains(out, "branch: test") {
+		t.Fatalf("expected completed branch value to remain visible, got: %q", out)
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -843,6 +843,93 @@ func TestConfirmInlineLineModel_IsMultiline(t *testing.T) {
 	}
 }
 
+func TestConfirmInlineLineModel_HidesStepWhileConfirming(t *testing.T) {
+	model := newConfirmInlineLineModel("Apply changes? (default: No)", DefaultTheme(), false)
+	model.confirming = true
+
+	out := model.View()
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected confirming view to hide step, got: %q", out)
+	}
+}
+
+func TestCreateFlowView_ShowsPendingModeInContext(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"",
+		"",
+	)
+
+	view := model.View()
+	if !strings.Contains(view, "Context") {
+		t.Fatalf("expected context section, got: %q", view)
+	}
+	if !strings.Contains(view, "• mode: ") && !strings.Contains(view, "• mode:") {
+		t.Fatalf("expected pending mode line in context, got: %q", view)
+	}
+}
+
+func TestInputsModelPresetView_ShowsPendingPresetInContext(t *testing.T) {
+	model := newInputsModel("title", []string{"repo-a"}, "", "", DefaultTheme(), false)
+
+	view := model.View()
+	if !strings.Contains(view, "Context") {
+		t.Fatalf("expected context section, got: %q", view)
+	}
+	if !strings.Contains(view, "• preset: ") && !strings.Contains(view, "• preset:") {
+		t.Fatalf("expected pending preset line in context, got: %q", view)
+	}
+}
+
+func TestCreateFlowDescriptionView_ShowsPendingDescriptionInContext(t *testing.T) {
+	model := newCreateFlowModel(
+		"gion manifest add",
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		DefaultTheme(),
+		false,
+		"",
+		"",
+	)
+	model.stage = createStagePresetDesc
+	model.mode = "preset"
+	model.presetModel.preset = "gion"
+	model.presetModel.workspaceID = "ws-test"
+
+	view := model.View()
+	if !strings.Contains(view, "• description: ") && !strings.Contains(view, "• description:") {
+		t.Fatalf("expected pending description line in context, got: %q", view)
+	}
+}
+
 func TestInputsModelPresetView_UsesFilterAssistLines(t *testing.T) {
 	model := newInputsModel("title", []string{"cwrds", "gion", "kra"}, "", "", DefaultTheme(), false)
 	model.search.SetValue("g")
@@ -990,5 +1077,21 @@ func TestPresetNameModel_UsesBottomInputAssistLines(t *testing.T) {
 	}
 	if !strings.Contains(view, "enter confirm  esc cancel") {
 		t.Fatalf("expected text input footer, got: %q", view)
+	}
+	if !strings.Contains(view, "• preset name: ") && !strings.Contains(view, "• preset name:") {
+		t.Fatalf("expected pending preset name line in context, got: %q", view)
+	}
+}
+
+func TestInputInlineModel_ShowsPendingLabelInContext(t *testing.T) {
+	model := newInputInlineModel("description", "", nil, DefaultTheme(), false)
+	model.input.SetValue("draft")
+
+	view := model.View()
+	if !strings.Contains(view, "Context") {
+		t.Fatalf("expected context section, got: %q", view)
+	}
+	if !strings.Contains(view, "• description: ") && !strings.Contains(view, "• description:") {
+		t.Fatalf("expected pending input label in context, got: %q", view)
 	}
 }

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -836,14 +836,14 @@ func TestInputsModelPresetRows_ShowTreeAndSelectionMarkers(t *testing.T) {
 	renderChoiceList(&b, []string{"cwrds", "gion", "kra"}, 1, 10, "gion", false, false, DefaultTheme())
 
 	out := b.String()
-	if !strings.Contains(out, "○ ├─  cwrds") {
-		t.Fatalf("expected non-last preset row to use tree mid connector, got: %q", out)
+	if !strings.Contains(out, "○ cwrds") {
+		t.Fatalf("expected preset row to use flat selector formatting, got: %q", out)
 	}
-	if !strings.Contains(out, "> ● ├─  gion") {
+	if !strings.Contains(out, "> ● gion") {
 		t.Fatalf("expected focused selected preset row, got: %q", out)
 	}
-	if !strings.Contains(out, "○ └─  kra") {
-		t.Fatalf("expected last preset row to use tree last connector, got: %q", out)
+	if !strings.Contains(out, "○ kra") {
+		t.Fatalf("expected trailing preset row to use flat selector formatting, got: %q", out)
 	}
 }
 

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -918,3 +918,27 @@ func TestPresetRepoSelectView_HidesAssistLinesWhileConfirming(t *testing.T) {
 		t.Fatalf("expected selected repo value in header while confirming, got: %q", view)
 	}
 }
+
+func TestInputsModelPresetConfirm_TransitionsToWorkspaceInput(t *testing.T) {
+	model := newInputsModel("title", []string{"gion"}, "", "", DefaultTheme(), false)
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(inputsModel)
+	if !next.confirming {
+		t.Fatalf("expected preset selector to enter confirming state")
+	}
+
+	updated, _ = next.Update(singleSelectConfirmDoneMsg{})
+	next = updated.(inputsModel)
+	if next.stage != stageWorkspace {
+		t.Fatalf("expected preset confirm to transition to workspace input, got stage=%v", next.stage)
+	}
+
+	view := next.View()
+	if !strings.Contains(view, "• workspace id:") {
+		t.Fatalf("expected workspace id prompt after preset confirm, got: %q", view)
+	}
+	if !strings.Contains(view, "  └─ ") {
+		t.Fatalf("expected inline workspace input line after preset confirm, got: %q", view)
+	}
+}

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -788,11 +788,11 @@ func TestBranchInputModel_SeparateInputLineKeepsBranchVisible(t *testing.T) {
 	model.separateInputLine = true
 
 	out := model.ViewWithHeader("repo: git@github.com:tasuku43/gion.git")
-	if !strings.Contains(out, "branch:") {
-		t.Fatalf("expected output to contain branch line")
+	if !strings.Contains(out, "input: issue/96") {
+		t.Fatalf("expected output to contain bottom input line")
 	}
-	if !strings.Contains(out, "issue/96") {
-		t.Fatalf("expected output to contain current input value")
+	if !strings.Contains(out, "enter confirm  esc cancel") {
+		t.Fatalf("expected output to contain text input footer")
 	}
 }
 
@@ -938,7 +938,26 @@ func TestInputsModelPresetConfirm_TransitionsToWorkspaceInput(t *testing.T) {
 	if !strings.Contains(view, "• workspace id:") {
 		t.Fatalf("expected workspace id prompt after preset confirm, got: %q", view)
 	}
-	if !strings.Contains(view, "  └─ ") {
-		t.Fatalf("expected inline workspace input line after preset confirm, got: %q", view)
+	if !strings.Contains(view, "input:") {
+		t.Fatalf("expected bottom input line after preset confirm, got: %q", view)
+	}
+	if !strings.Contains(view, "enter confirm  esc cancel") {
+		t.Fatalf("expected text input footer after preset confirm, got: %q", view)
+	}
+}
+
+func TestPresetNameModel_UsesBottomInputAssistLines(t *testing.T) {
+	model := newPresetNameModel("title", "", DefaultTheme(), false)
+	model.input.SetValue("my-preset")
+
+	view := model.View()
+	if strings.Contains(view, "• preset name: my-preset") {
+		t.Fatalf("active preset name should not be echoed in header, got: %q", view)
+	}
+	if !strings.Contains(view, "input: my-preset") {
+		t.Fatalf("expected bottom input line, got: %q", view)
+	}
+	if !strings.Contains(view, "enter confirm  esc cancel") {
+		t.Fatalf("expected text input footer, got: %q", view)
 	}
 }

--- a/internal/ui/prompt_scroll_test.go
+++ b/internal/ui/prompt_scroll_test.go
@@ -811,3 +811,110 @@ func TestConfirmInlineLineModel_IsMultiline(t *testing.T) {
 		t.Fatalf("expected output to contain connector")
 	}
 }
+
+func TestInputsModelPresetView_UsesFilterAssistLines(t *testing.T) {
+	model := newInputsModel("title", []string{"cwrds", "gion", "kra"}, "", "", DefaultTheme(), false)
+	model.search.SetValue("g")
+
+	view := model.View()
+	if strings.Contains(view, "• preset: g") {
+		t.Fatalf("active filter should not be echoed in preset header, got: %q", view)
+	}
+	if !strings.Contains(view, "filter: g") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "space/enter select") {
+		t.Fatalf("expected single-select footer line, got: %q", view)
+	}
+	if !strings.Contains(view, "\n\n  filter: g") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
+	}
+}
+
+func TestInputsModelPresetRows_ShowTreeAndSelectionMarkers(t *testing.T) {
+	var b strings.Builder
+	renderChoiceList(&b, []string{"cwrds", "gion", "kra"}, 1, 10, "gion", false, false, DefaultTheme())
+
+	out := b.String()
+	if !strings.Contains(out, "○ ├─  cwrds") {
+		t.Fatalf("expected non-last preset row to use tree mid connector, got: %q", out)
+	}
+	if !strings.Contains(out, "> ● ├─  gion") {
+		t.Fatalf("expected focused selected preset row, got: %q", out)
+	}
+	if !strings.Contains(out, "○ └─  kra") {
+		t.Fatalf("expected last preset row to use tree last connector, got: %q", out)
+	}
+}
+
+func TestInputsModelPresetView_HidesAssistLinesWhileConfirming(t *testing.T) {
+	model := newInputsModel("title", []string{"cwrds", "gion"}, "", "", DefaultTheme(), false)
+	model.preset = "gion"
+	model.confirming = true
+
+	view := model.View()
+	if !strings.Contains(view, "• preset: gion") {
+		t.Fatalf("expected confirmed preset to remain in header, got: %q", view)
+	}
+	if strings.Contains(view, "filter:") {
+		t.Fatalf("expected filter assist line to be hidden while confirming, got: %q", view)
+	}
+	if strings.Contains(view, "space/enter select") {
+		t.Fatalf("expected single-select footer line to be hidden while confirming, got: %q", view)
+	}
+}
+
+func TestInputsModelPresetModel_EnterStartsConfirmTimer(t *testing.T) {
+	model := newInputsModel("title", []string{"cwrds"}, "", "", DefaultTheme(), false)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(inputsModel)
+	if !next.confirming {
+		t.Fatalf("expected preset selector to enter confirming state")
+	}
+	if next.preset != "cwrds" {
+		t.Fatalf("expected selected preset to be retained, got: %q", next.preset)
+	}
+	if cmd == nil {
+		t.Fatalf("expected confirm timer command")
+	}
+}
+
+func TestPresetRepoSelectView_UsesFilterAssistLines(t *testing.T) {
+	model := newPresetRepoSelectModel("title", "app", []PromptChoice{
+		{Label: "github.com/org/repo-a", Value: "a"},
+		{Label: "github.com/org/repo-b", Value: "b"},
+	}, DefaultTheme(), false)
+	model.stage = stageRepoSelect
+	model.repoInput.Focus()
+	model.repoInput.SetValue("repo")
+
+	view := model.View()
+	if strings.Contains(view, "• repo: repo") {
+		t.Fatalf("active filter should not be echoed in preset repo header, got: %q", view)
+	}
+	if !strings.Contains(view, "filter: repo") {
+		t.Fatalf("expected filter assist line, got: %q", view)
+	}
+	if !strings.Contains(view, "\n\n  filter: repo") {
+		t.Fatalf("expected a blank line before filter assist line, got: %q", view)
+	}
+}
+
+func TestPresetRepoSelectView_HidesAssistLinesWhileConfirming(t *testing.T) {
+	model := newPresetRepoSelectModel("title", "app", []PromptChoice{
+		{Label: "github.com/org/repo-a", Value: "a"},
+		{Label: "github.com/org/repo-b", Value: "b"},
+	}, DefaultTheme(), false)
+	model.stage = stageRepoSelect
+	model.selected = []string{"a"}
+	model.confirming = true
+
+	view := model.View()
+	if strings.Contains(view, "filter:") || strings.Contains(view, "selected: 1/2") {
+		t.Fatalf("expected preset repo confirm view to hide assist lines, got: %q", view)
+	}
+	if !strings.Contains(view, "• repo: a") {
+		t.Fatalf("expected selected repo value in header while confirming, got: %q", view)
+	}
+}

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -38,7 +38,11 @@ func (r *Renderer) Blank() {
 
 func (r *Renderer) Section(title string) {
 	switch strings.ToLower(strings.TrimSpace(title)) {
+	case "context":
+		debuglog.SetPhase("inputs")
 	case "inputs":
+		debuglog.SetPhase("inputs")
+	case "step":
 		debuglog.SetPhase("inputs")
 	case "info":
 		debuglog.SetPhase("info")

--- a/internal/ui/renderer_step_test.go
+++ b/internal/ui/renderer_step_test.go
@@ -36,9 +36,7 @@ func TestGroupedStepLogger_RendersTreePerStep(t *testing.T) {
 	wantLines := []string{
 		"  • remove workspace test",
 		"    ├─ $ git worktree remove --force",
-		"    │  /tmp/test/repo-a",
 		"    └─ $ git worktree remove --force",
-		"       /tmp/test/repo-b",
 	}
 	want := strings.Join(wantLines, "\n") + "\n"
 	if got != want {
@@ -66,11 +64,7 @@ func TestGroupedStepLogger_RendersGroupedRepoTree(t *testing.T) {
 	wantLines := []string{
 		"  • remove workspace test",
 		"    ├─ repo-a",
-		"    │  ├─ $ git worktree remove --force",
-		"    │  └─ /tmp/test/repo-a",
 		"    └─ repo-b",
-		"       ├─ $ git worktree remove --force",
-		"       └─ /tmp/test/repo-b",
 	}
 	want := strings.Join(wantLines, "\n") + "\n"
 	if got != want {

--- a/internal/ui/renderer_step_test.go
+++ b/internal/ui/renderer_step_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/tasuku43/gion/internal/infra/output"
@@ -16,5 +17,31 @@ func TestRendererStepLog_FormatsWithConnector(t *testing.T) {
 	got := b.String()
 	if got != "  "+output.LogConnector+" $ git worktree remove --force\n" {
 		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestGroupedStepLogger_RendersTreePerStep(t *testing.T) {
+	var b bytes.Buffer
+	renderer := NewRenderer(&b, DefaultTheme(), false)
+	logger := NewGroupedStepLogger(renderer)
+
+	logger.Step("remove workspace test")
+	logger.Log("$ git worktree remove --force")
+	logger.LogOutput("/tmp/test/gion")
+	logger.Log("$ git worktree remove --force")
+	logger.LogOutput("/tmp/test/kra")
+	logger.Flush()
+
+	got := b.String()
+	wantLines := []string{
+		"  • remove workspace test",
+		"    ├─ $ git worktree remove --force",
+		"    │  /tmp/test/gion",
+		"    └─ $ git worktree remove --force",
+		"       /tmp/test/kra",
+	}
+	want := strings.Join(wantLines, "\n") + "\n"
+	if got != want {
+		t.Fatalf("unexpected output:\n%s\nwant:\n%s", got, want)
 	}
 }

--- a/internal/ui/renderer_step_test.go
+++ b/internal/ui/renderer_step_test.go
@@ -27,18 +27,50 @@ func TestGroupedStepLogger_RendersTreePerStep(t *testing.T) {
 
 	logger.Step("remove workspace test")
 	logger.Log("$ git worktree remove --force")
-	logger.LogOutput("/tmp/test/gion")
+	logger.LogOutput("/tmp/test/repo-a")
 	logger.Log("$ git worktree remove --force")
-	logger.LogOutput("/tmp/test/kra")
+	logger.LogOutput("/tmp/test/repo-b")
 	logger.Flush()
 
 	got := b.String()
 	wantLines := []string{
 		"  • remove workspace test",
 		"    ├─ $ git worktree remove --force",
-		"    │  /tmp/test/gion",
+		"    │  /tmp/test/repo-a",
 		"    └─ $ git worktree remove --force",
-		"       /tmp/test/kra",
+		"       /tmp/test/repo-b",
+	}
+	want := strings.Join(wantLines, "\n") + "\n"
+	if got != want {
+		t.Fatalf("unexpected output:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestGroupedStepLogger_RendersGroupedRepoTree(t *testing.T) {
+	var b bytes.Buffer
+	renderer := NewRenderer(&b, DefaultTheme(), false)
+	logger := NewGroupedStepLogger(renderer)
+
+	logger.Step("remove workspace test")
+	logger.BeginGroup("repo-a")
+	logger.Log("$ git worktree remove --force")
+	logger.Log("/tmp/test/repo-a")
+	logger.EndGroup()
+	logger.BeginGroup("repo-b")
+	logger.Log("$ git worktree remove --force")
+	logger.Log("/tmp/test/repo-b")
+	logger.EndGroup()
+	logger.Flush()
+
+	got := b.String()
+	wantLines := []string{
+		"  • remove workspace test",
+		"    ├─ repo-a",
+		"    │  ├─ $ git worktree remove --force",
+		"    │  └─ /tmp/test/repo-a",
+		"    └─ repo-b",
+		"       ├─ $ git worktree remove --force",
+		"       └─ /tmp/test/repo-b",
 	}
 	want := strings.Join(wantLines, "\n") + "\n"
 	if got != want {


### PR DESCRIPTION
## Summary
- align selector, text input, and confirm prompt behavior under a shared prompt grammar
- replace the old `Inputs` framing with `Context` and `Step` so confirmed state and active interaction are clearly separated
- summarize normal `Apply` output by workspace and repo instead of showing raw git commands, making it read consistently with `Plan`
- tighten spacing, assist-line rendering, and confirm-state transitions across prompt flows, and add regression coverage

## Background
This PR started as a narrower preset-selector cleanup, but the follow-up work exposed a broader prompt UI consistency problem. In practice, selector rendering, text input rendering, confirm prompts, and apply output were all using slightly different presentation rules. That made small changes feel local and left the overall interaction model uneven.

The goal of this PR is not to introduce a shared external UI library yet. Instead, it brings `gion` to a stable minimum contract internally so the CLI feels coherent first, and only then becomes easier to extract into reusable primitives later.

## What Changed
### 1. Unified preset and selector behavior
- aligned preset selection with the shared single-select grammar
- aligned preset repo selection with the shared multi-select filter/footer/confirm behavior
- fixed preset confirm transitions so the flow reliably advances to the next stage
- flattened preset rows to match the rest of the selector UI instead of using a special tree-only shape

### 2. Shared assist-line rendering for filter and input
- shared the renderer used for `filter:` and `input:` assist lines, differing only by label
- enabled the Bubble Tea pseudo cursor in both filter and input lines
- aligned branch, workspace id, description, preset name, and apply confirmation inputs with the same bottom-composer layout
- kept branch entry as a two-line interaction: context above, shared `input:` line below

### 3. Reframed prompt UI as `Context` + `Step`
- replaced the old `Inputs` framing with `Context` and `Step`
- `Context` now shows confirmed state, and remains visible throughout the flow
- the current unresolved field is shown in `Context` as a muted pending line
- `Step` owns the active selector, text input, or confirmation control
- once a confirmation completes, `Step` no longer lingers in the final visible frame
- updated selector height calculations so the additional context lines do not break compact terminal layouts

### 4. Simplified normal `Apply` output
- removed raw `git worktree add/remove` command logs from normal `Apply` output
- summarized add/update/remove results at the workspace -> repo level so `Apply` reads with the same mental model as `Plan`
- grouped remove operations consistently and aligned indent/tree behavior with the plan output
- tightened the spacing between `Plan` and `Apply` once the confirmation `Step` disappears

### 5. Consistency fixes around spacing and prompt transitions
- moved info-section spacing responsibility into the manifest mutation hooks where appropriate
- aligned the destructive-apply confirmation prompt with the same `input:` style used elsewhere
- improved the `giongo` workspace selector with a clearer focus marker and less duplicated detail text

## Scope
This PR is primarily a presentation-layer change centered around:
- `internal/ui/prompt.go`
- `internal/ui/frame.go`
- `internal/ui/grouped_step_logger.go`
- `internal/cli/apply.go`
- `internal/app/apply/apply.go`

It affects the visible behavior of flows such as:
- `gion manifest add`
- `gion manifest rm`
- `gion manifest preset add`
- `giongo`

This does not change manifest semantics or the intended domain behavior of add/update/remove operations.

## Testing
- `go test ./internal/ui -count=1`
- `go test ./internal/cli -count=1`
- `go test ./internal/ui ./internal/cli -count=1`
- `go test ./internal/ui ./internal/cli ./internal/domain/workspace ./internal/app/apply -count=1`

## Follow-up Direction
This PR intentionally stops short of extracting a shared UI library. The immediate target is internal consistency inside `gion`: shared selector grammar, shared assist-line primitives, stable section spacing, and clearer `Plan`/`Apply` structure. Once those primitives settle, they will be in a better position to be reused or extracted cleanly.